### PR TITLE
Fix(travis): Updating import path for package openebs/ark-plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,15 +17,15 @@ BIN = $(wildcard ark-*)
 
 # This repo's root import path (under GOPATH).
 # TODO change
-REPO := github.com/openebs/ark-plugin
+REPO := github.com/openebs/velero-plugin
 
 BUILD_IMAGE ?= gcr.io/heptio-images/golang:1.9-alpine3.6
 
-# list only ark-plugin source code directories
+# list only velero-plugin source code directories
 PACKAGES = $(shell go list ./... | grep -v 'vendor')
 
 
-IMAGE ?= openebs/ark-plugin
+IMAGE ?= openebs/velero-plugin
 
 ifeq (${IMAGE_TAG}, )
 	IMAGE_TAG = ci

--- a/ark-blockstore-cstor/main.go
+++ b/ark-blockstore-cstor/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	arkplugin "github.com/heptio/ark/pkg/plugin"
-	snap "github.com/openebs/ark-plugin/pkg/snapshot"
+	snap "github.com/openebs/velero-plugin/pkg/snapshot"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/cstor/cstor.go
+++ b/pkg/cstor/cstor.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/heptio/ark/pkg/util/collections"
-	cloud "github.com/openebs/ark-plugin/pkg/clouduploader"
+	cloud "github.com/openebs/velero-plugin/pkg/clouduploader"
 	"github.com/pkg/errors"
 	/* Due to dependency conflict, please ensure openebs
 	 * dependency manually instead of using dep

--- a/pkg/snapshot/snap.go
+++ b/pkg/snapshot/snap.go
@@ -18,7 +18,7 @@ package snapshot
 
 import (
 	"github.com/heptio/ark/pkg/cloudprovider"
-	"github.com/openebs/ark-plugin/pkg/cstor"
+	"github.com/openebs/velero-plugin/pkg/cstor"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 )


### PR DESCRIPTION
Changes:
- Updating import path from `openebs/ark-plugin` to `openebs/velero-plugin`

Signed-off-by: mayank <mayank.patel@cloudbyte.com>