### PR TITLE
Fix(cherry-pick, VolumeSnapshotLocation): using prefix for backup path instead of file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ spec:
   provider: openebs.io/cstor-blockstore
   config:
     bucket: <YOUR_BUCKET>
-    prefix: <PREFIX_FOR_BACKUP_PATH>
+    prefix: <PREFIX_FOR_BACKUP_NAME>
+    backupPathPrefix: <PREFIX_FOR_BACKUP_PATH>
     provider: <GCP_OR_AWS>
     region: <AWS_REGION>
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ spec:
   provider: openebs.io/cstor-blockstore
   config:
     bucket: <YOUR_BUCKET>
-    prefix: <PREFIX_FOR_BACKUP_NAME>
+    prefix: <PREFIX_FOR_BACKUP_PATH>
     provider: <GCP_OR_AWS>
     region: <AWS_REGION>
 ```

--- a/example/06-volumesnapshotlocation.yaml
+++ b/example/06-volumesnapshotlocation.yaml
@@ -22,6 +22,7 @@ spec:
   provider: openebs.io/cstor-blockstore
   config:
     bucket: <YOUR_BUCKET>
-    prefix: <PREFIX_FOR_BACKUP_NAME >
+    prefix: <PREFIX_FOR_BACKUP_NAME>
+    backupPathPrefix: <PREFIX_FOR_BACKUP_PATH>
     provider: <GCP_OR_AWS>
     region: <AWS_REGION>

--- a/pkg/clouduploader/conn.go
+++ b/pkg/clouduploader/conn.go
@@ -47,6 +47,9 @@ const (
 	// PREFIX prefix key
 	PREFIX = "prefix"
 
+	// BackupPathPrefix key for backupPathPrefix
+	BackupPathPrefix = "backupPathPrefix"
+
 	// REGION region key
 	REGION = "region"
 
@@ -85,6 +88,9 @@ type Conn struct {
 
 	// prefix is used for file name
 	prefix string
+
+	// backupPathPrefix is used for backup path
+	backupPathPrefix string
 
 	// file represent remote file name
 	file string
@@ -177,6 +183,12 @@ func (c *Conn) Init(config map[string]string) error {
 		prefix = ""
 	}
 	c.prefix = prefix
+
+	backupPathPrefix, err := config[BackupPathPrefix]
+	if !err {
+		backupPathPrefix = ""
+	}
+	c.backupPathPrefix = backupPathPrefix
 
 	c.ctx = context.Background()
 	b, berr := c.setupBucket(c.ctx, provider, bucketName, config)

--- a/pkg/clouduploader/operation.go
+++ b/pkg/clouduploader/operation.go
@@ -116,5 +116,8 @@ func (c *Conn) Read(file string) ([]byte, bool) {
 
 // GenerateRemoteFilename will create a file-name specific for given backup
 func (c *Conn) GenerateRemoteFilename(file, backup string) string {
-	return c.prefix + "/" + backupDir + "/" + backup + "/" + file + "-" + backup
+	if len(c.backupPathPrefix) == 0 {
+		return backupDir + "/" + backup + "/" + c.prefix + "-" + file + "-" + backup
+	}
+	return c.backupPathPrefix + "/" + backupDir + "/" + backup + "/" + c.prefix + "-" + file + "-" + backup
 }

--- a/pkg/clouduploader/operation.go
+++ b/pkg/clouduploader/operation.go
@@ -116,5 +116,5 @@ func (c *Conn) Read(file string) ([]byte, bool) {
 
 // GenerateRemoteFilename will create a file-name specific for given backup
 func (c *Conn) GenerateRemoteFilename(file, backup string) string {
-	return backupDir + "/" + backup + "/" + c.prefix + "-" + file + "-" + backup
+	return c.prefix + "/" + backupDir + "/" + backup + "/" + file + "-" + backup
 }


### PR DESCRIPTION
Cherry-pick for https://github.com/openebs/velero-plugin/pull/25
Signed-off-by: mayank <mayank.patel@mayadata.io>