### PR TITLE
Fix(VolumeID) : adding a check for CStor Volume during backup

### DIFF
--- a/pkg/clouduploader/conn.go
+++ b/pkg/clouduploader/conn.go
@@ -130,8 +130,8 @@ func (c *Conn) setupGCP(ctx context.Context, bucket string, config map[string]st
 func (c *Conn) setupAWS(ctx context.Context, bucketName string, config map[string]string) (*blob.Bucket, error) {
 	var awscred string
 
-	region, err := config[REGION]
-	if !err {
+	region, ok := config[REGION]
+	if !ok {
 		return nil, errors.New("No region provided for AWS")
 	}
 
@@ -166,34 +166,34 @@ func (c *Conn) setupAWS(ctx context.Context, bucketName string, config map[strin
 
 // Init initialize connection to cloud blob storage
 func (c *Conn) Init(config map[string]string) error {
-	provider, err := config[PROVIDER]
-	if !err {
+	provider, ok := config[PROVIDER]
+	if !ok {
 		return errors.New("Failed to get provider name")
 	}
 	c.provider = provider
 
-	bucketName, err := config[BUCKET]
-	if !err {
+	bucketName, ok := config[BUCKET]
+	if !ok {
 		return errors.New("Failed to get bucket name")
 	}
 	c.bucketname = bucketName
 
-	prefix, err := config[PREFIX]
-	if !err {
+	prefix, ok := config[PREFIX]
+	if !ok {
 		prefix = ""
 	}
 	c.prefix = prefix
 
-	backupPathPrefix, err := config[BackupPathPrefix]
-	if !err {
+	backupPathPrefix, ok := config[BackupPathPrefix]
+	if !ok {
 		backupPathPrefix = ""
 	}
 	c.backupPathPrefix = backupPathPrefix
 
 	c.ctx = context.Background()
-	b, berr := c.setupBucket(c.ctx, provider, bucketName, config)
-	if berr != nil {
-		return errors.Errorf("Failed to setup bucket : %s", berr.Error())
+	b, err := c.setupBucket(c.ctx, provider, bucketName, config)
+	if err != nil {
+		return errors.Errorf("Failed to setup bucket : %s", err.Error())
 	}
 	c.bucket = b
 	return nil


### PR DESCRIPTION
Changes:
- Whenever `velero-plugin` receives a snapshot request, it will check(using label `openebs.io/cas-type:cstor`) if PV is CStor PV or not.
           - If PV is having CStor label(`openebs.io/cas-type:cstor`) then `velero-plugin` will execute the snapshot action
       - If PV doesn't have the CStor label then `velero-plugin` will not execute the snapshot action.

-  Code refactoring 
       - Using var `ok` instead of var `err` to check error on fetching key from map.
       - Changed `casType` to `casTypeCStor` for `cstor`.

This PR fixes https://github.com/openebs/velero-plugin/issues/27

Signed-off-by: mayank <mayank.patel@mayadata.io>