### PR TITLE
fix(travis, misspell) : fixing spelling mistake

### DIFF
--- a/pkg/cstor/cstor.go
+++ b/pkg/cstor/cstor.go
@@ -215,7 +215,7 @@ func (p *Plugin) GetVolumeID(unstructuredPV runtime.Unstructured) (string, error
 		return "", errors.WithStack(err)
 	}
 
-	// If PV doesn't have sufficent info to consider as CStor Volume
+	// If PV doesn't have sufficient info to consider as CStor Volume
 	// then we will return empty volumeId and error as nil.
 	if pv.Name == "" ||
 		pv.Spec.StorageClassName == "" ||


### PR DESCRIPTION
Changes:
- Fixing spelling mistake in `pkg/cstor/cstor.go`.
       - `sufficient` spelled as `sufficent`.

Signed-off-by: mayank <mayank.patel@mayadata.io>