### PR TITLE
feat(config): adding support for new parameter `namespace` in volumesnapshotlocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ spec:
     provider: <GCP_OR_AWS>
     region: <AWS_REGION>
 ```
+Above configuration assumes that OpenEBS is installed in `openebs` namespace.
+If openebs is installed in different namespace then you need to add `spec.config.namespace: <OPENEBS_NAMESPACE>`.
+
 *Note:*
 
 - _`prefix` is for backup file name._

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ spec:
     provider: <GCP_OR_AWS>
     region: <AWS_REGION>
 ```
-Above configuration assumes that OpenEBS is installed in `openebs` namespace.
-If openebs is installed in different namespace then you need to add `spec.config.namespace: <OPENEBS_NAMESPACE>`.
+If you have multiple installation of openebs then you need to add `spec.config.namespace: <OPENEBS_NAMESPACE>`.
 
 *Note:*
 

--- a/example/06-volumesnapshotlocation.yaml
+++ b/example/06-volumesnapshotlocation.yaml
@@ -26,3 +26,4 @@ spec:
     backupPathPrefix: <PREFIX_FOR_BACKUP_PATH>
     provider: <GCP_OR_AWS>
     region: <AWS_REGION>
+    namespace: <OPENEBS_NAMESPACE>

--- a/pkg/snapshot/snap.go
+++ b/pkg/snapshot/snap.go
@@ -33,9 +33,8 @@ var _ velero.VolumeSnapshotter = (*BlockStore)(nil)
 
 // Init the plugin
 func (p *BlockStore) Init(config map[string]string) error {
-	p.Log.Infof("Initializing velero plugin for CStor %v", config)
+	p.Log.Infof("Initializing velero plugin for CStor")
 
-	// TODO check for type of volume
 	p.plugin = &cstor.Plugin{Log: p.Log}
 	return p.plugin.Init(config)
 }


### PR DESCRIPTION
Changes:
velero-plugin assumes that openebs is installed in namespace `openebs`.
If openebs is installed in different namespace then user can configure
this parameter to execute backup operation.

sample volumesnapshotlocation.yaml:
```
  spec:
    config:
      bucket: test_bucket
      namespace: ns1
      provider: gcp
    provider: openebs.io/cstor-blockstore
```

Signed-off-by: mayank <mayank.patel@mayadata.io>