### PR TITLE
fix(ci): adding check for healthy CVR

### DIFF
--- a/script/install-velero.sh
+++ b/script/install-velero.sh
@@ -55,7 +55,7 @@ export MAPI_ADDR="http://${MAPI_SVC_ADDR}:5656"
 export KUBERNETES_SERVICE_HOST="127.0.0.1"
 export KUBECONFIG=$HOME/.kube/config
 
-wget -O velero.tar.gz https://github.com/heptio/velero/releases/download/${VELERO_RELEASE}/velero-${VELERO_RELEASE}-linux-amd64.tar.gz
+wget -nv -O velero.tar.gz https://github.com/heptio/velero/releases/download/${VELERO_RELEASE}/velero-${VELERO_RELEASE}-linux-amd64.tar.gz
 mkdir velero
 tar xf velero.tar.gz -C velero
 velero=$PWD/velero/velero-${VELERO_RELEASE}-linux-amd64/velero
@@ -65,11 +65,11 @@ if [ ! -f ${velero} ]; then
 fi
 
 if [ ! -f minio ]; then
-	wget https://dl.min.io/server/minio/release/linux-amd64/minio
+	wget -nv https://dl.min.io/server/minio/release/linux-amd64/minio
 fi
 
 if [ ! -f mc ]; then
-	wget https://dl.min.io/client/mc/release/linux-amd64/mc
+	wget -nv https://dl.min.io/client/mc/release/linux-amd64/mc
 fi
 chmod +x minio
 chmod +x mc

--- a/tests/openebs/logs.go
+++ b/tests/openebs/logs.go
@@ -17,8 +17,6 @@ limitations under the License.
 package openebs
 
 import (
-	"fmt"
-
 	k8s "github.com/openebs/velero-plugin/tests/k8s"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -91,7 +89,6 @@ func getPodContainerList(podList *corev1.PodList) [][]string {
 	for _, p := range podList.Items {
 		for _, c := range p.Spec.Containers {
 			pod = append(pod, []string{p.Name, c.Name})
-			fmt.Println(c.Name)
 		}
 	}
 	return pod

--- a/tests/openebs/logs.go
+++ b/tests/openebs/logs.go
@@ -26,12 +26,14 @@ import (
 const (
 	mayaAPIPodLabel = "openebs.io/component-name=maya-apiserver"
 	cstorPodLabel   = "app=cstor-pool"
+	pvcPodLabel     = "openebs.io/target=cstor-target"
 )
 
 // DumpLogs will dump openebs logs
 func (c *ClientSet) DumpLogs() error {
 	mayaPod := c.getMayaAPIServerPodName()
 	spcPod := c.getSPCPodName()
+	pvcPod := c.getPVCPodName()
 
 	for _, v := range mayaPod {
 		_ = k8s.Client.DumpLogs(OpenEBSNs, v[0], v[1])
@@ -39,6 +41,10 @@ func (c *ClientSet) DumpLogs() error {
 	for _, v := range spcPod {
 		_ = k8s.Client.DumpLogs(OpenEBSNs, v[0], v[1])
 	}
+	for _, v := range pvcPod {
+		_ = k8s.Client.DumpLogs(OpenEBSNs, v[0], v[1])
+	}
+
 	return nil
 }
 
@@ -59,6 +65,18 @@ func (c *ClientSet) getMayaAPIServerPodName() [][]string {
 func (c *ClientSet) getSPCPodName() [][]string {
 	podList, err := k8s.Client.GetPodList(OpenEBSNs,
 		cstorPodLabel,
+	)
+	if err != nil {
+		return [][]string{}
+	}
+	return getPodContainerList(podList)
+}
+
+// getPVCPodName return PVC pod name and container
+// {{"pod1","container1"},{"pod2","container2"},}
+func (c *ClientSet) getPVCPodName() [][]string {
+	podList, err := k8s.Client.GetPodList(OpenEBSNs,
+		pvcPodLabel,
 	)
 	if err != nil {
 		return [][]string{}

--- a/tests/openebs/storage_install.go
+++ b/tests/openebs/storage_install.go
@@ -42,6 +42,9 @@ var (
 
 	// PVCName for PVC
 	PVCName string
+
+	// AppPVC created by openebs
+	AppPVC *corev1.PersistentVolumeClaim
 )
 
 const (
@@ -105,7 +108,10 @@ func (c *ClientSet) CreateVolume(pvcYAML, pvcNs string, wait bool) error {
 	time.Sleep(5 * time.Second)
 	PVCName = pvc.Name
 	if wait {
-		err = c.waitForHealthyCVR(&pvc)
+		err = c.WaitForHealthyCVR(&pvc)
+	}
+	if err != nil {
+		AppPVC = &pvc
 	}
 	return err
 }

--- a/tests/openebs/storage_install.go
+++ b/tests/openebs/storage_install.go
@@ -110,7 +110,7 @@ func (c *ClientSet) CreateVolume(pvcYAML, pvcNs string, wait bool) error {
 	if wait {
 		err = c.WaitForHealthyCVR(&pvc)
 	}
-	if err != nil {
+	if err == nil {
 		AppPVC = &pvc
 	}
 	return err

--- a/tests/openebs/storage_status.go
+++ b/tests/openebs/storage_status.go
@@ -36,7 +36,8 @@ const (
 	CVRMaxRetry = 5
 )
 
-func (c *ClientSet) waitForHealthyCVR(pvc *v1.PersistentVolumeClaim) error {
+// WaitForHealthyCVR wait till CVR for given PVC becomes healthy
+func (c *ClientSet) WaitForHealthyCVR(pvc *v1.PersistentVolumeClaim) error {
 	dumpLog := 0
 	for {
 		if healthy := c.CheckCVRStatus(pvc.Name,

--- a/tests/sanity/backup_test.go
+++ b/tests/sanity/backup_test.go
@@ -72,6 +72,10 @@ var _ = Describe("Backup/Restore Test", func() {
 		It("Backup Test 1", func() {
 			var status v1.BackupPhase
 			By("Creating a backup")
+
+			err = openebs.Client.WaitForHealthyCVR(openebs.AppPVC)
+			Expect(err).NotTo(HaveOccurred())
+
 			backupName, status, err = velero.Client.CreateBackup(AppNs)
 			if ((err != nil) || status != v1.BackupPhaseCompleted) &&
 				len(backupName) != 0 {

--- a/tests/sanity/backup_test.go
+++ b/tests/sanity/backup_test.go
@@ -18,6 +18,7 @@ package sanity
 
 import (
 	"testing"
+	"time"
 
 	v1 "github.com/heptio/velero/pkg/apis/velero/v1"
 	. "github.com/onsi/ginkgo"
@@ -75,6 +76,8 @@ var _ = Describe("Backup/Restore Test", func() {
 
 			err = openebs.Client.WaitForHealthyCVR(openebs.AppPVC)
 			Expect(err).NotTo(HaveOccurred())
+			// There are chances that istgt is not updated, but replica is healthy
+			time.Sleep(30 * time.Second)
 
 			backupName, status, err = velero.Client.CreateBackup(AppNs)
 			if ((err != nil) || status != v1.BackupPhaseCompleted) &&


### PR DESCRIPTION
Changes:
- Adding a check for healthy CVR before triggering a backup.

  In the current version, we check for healthy CVR during setup only.
  There might be some chances of cstor pod restart and CVR
  becomes degraded when we trigger the backup.

Signed-off-by: mayank <mayank.patel@mayadata.io>