### PR TITLE
fix(statefuleset): update storageclass from PVC annotation

### DIFF
--- a/pkg/cstor/pvc_operation.go
+++ b/pkg/cstor/pvc_operation.go
@@ -59,6 +59,11 @@ func (p *Plugin) backupPVC(volumeID string) error {
 
 	bkpPvc.ResourceVersion = ""
 	bkpPvc.SelfLink = ""
+	if bkpPvc.Spec.StorageClassName == nil || len(*bkpPvc.Spec.StorageClassName) == 0 {
+		sc := bkpPvc.Annotations[v1.BetaStorageClassAnnotation]
+		bkpPvc.Spec.StorageClassName = &sc
+	}
+
 	bkpPvc.Annotations = nil
 	bkpPvc.UID = ""
 	bkpPvc.Spec.VolumeName = ""


### PR DESCRIPTION
Changes:
- STS uses StorageClass from PVC Annotation or PVC Spec. This PR checks for PVC's annotation for the StorageClass.
 
Signed-off-by: mayank <mayank.patel@mayadata.io>