### PR TITLE
feat(s3, partSize) :  support for multiPartChunkSize

### DIFF
--- a/example/06-volumesnapshotlocation.yaml
+++ b/example/06-volumesnapshotlocation.yaml
@@ -42,7 +42,8 @@ spec:
 
 
 ### Sample VolumeSnapshotLocation YAML for various cloud-providers
-# ---
+# # For GCP
+#---
 # apiVersion: velero.io/v1
 # kind: VolumeSnapshotLocation
 # metadata:
@@ -55,29 +56,31 @@ spec:
 #     prefix: cstor
 #     provider: gcp
 
+#
+# # For MinIO
 # ---
 # apiVersion: velero.io/v1
 # kind: VolumeSnapshotLocation
 # metadata:
-#   name: minio-bucket
+#   name: minio
 #   namespace: velero
 # spec:
 #   provider: openebs.io/cstor-blockstore
 #   config:
 #     bucket: openebs-velero-example
+#
 #     prefix: cstor
+#
 #     provider: aws
 #
-#     # The AWS region where the bucket is located.
+#     # The region where the server is located.
 #     region: minio
 #
 #     # Whether to use path-style addressing instead of virtual hosted bucket addressing.
 #     # Set to "true"
-#     # if using a local storage service like MinIO.
 #     s3ForcePathStyle: "true"
 #
-#     # AWS S3 URL, By default it will be generated from "region" and "bucket"
-#     # This field needs to be set for local storage services like MinIO.
+#     # S3 URL, By default it will be generated from "region" and "bucket"
 #     s3Url: http://minio.velero.svc:9000
 #
 #     # You can specify the multipart_chunksize  here for explicitness.
@@ -85,6 +88,8 @@ spec:
 #     # If not set then it will be calculated from the file size
 #     multiPartChunkSize: 64Mi
 
+#
+# # For AWS
 # ---
 # apiVersion: velero.io/v1
 # kind: VolumeSnapshotLocation
@@ -95,7 +100,9 @@ spec:
 #   provider: openebs.io/cstor-blockstore
 #   config:
 #     bucket: openebs-velero-example
+#
 #     prefix: cstor
+#
 #     provider: aws
 #
 #     # The AWS region where the bucket is located.

--- a/example/06-volumesnapshotlocation.yaml
+++ b/example/06-volumesnapshotlocation.yaml
@@ -84,7 +84,8 @@ spec:
 #     s3Url: http://minio.velero.svc:9000
 #
 #     # You can specify the multipart_chunksize  here for explicitness.
-#     # Minimum value can be set is 5Mi (5*1024*1024 Bytes).. expected value (5Mi/Gi)
+#     # multiPartChunkSize can be from 5Mi(5*1024*1024 Bytes) to 5Gi
+#     # For more information: https://docs.min.io/docs/minio-server-limits-per-tenant.html
 #     # If not set then it will be calculated from the file size
 #     multiPartChunkSize: 64Mi
 
@@ -109,6 +110,7 @@ spec:
 #     region: ap-south-1
 #
 #     # You can specify the multipart_chunksize  here for explicitness.
-#     # Minimum value can be set is 5Mi (5*1024*1024 Bytes).. expected value (5Mi/Gi)
+#     # multiPartChunkSize can be from 5Mi(5*1024*1024 Bytes) to 5Gi
+#     # For more information: https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
 #     # If not set then it will be calculated from the file size
 #     multiPartChunkSize: 64Mi

--- a/example/06-volumesnapshotlocation.yaml
+++ b/example/06-volumesnapshotlocation.yaml
@@ -67,9 +67,23 @@ spec:
 #     bucket: openebs-velero-example
 #     prefix: cstor
 #     provider: aws
+#
+#     # The AWS region where the bucket is located.
 #     region: minio
+#
+#     # Whether to use path-style addressing instead of virtual hosted bucket addressing.
+#     # Set to "true"
+#     # if using a local storage service like MinIO.
 #     s3ForcePathStyle: "true"
+#
+#     # AWS S3 URL, By default it will be generated from "region" and "bucket"
+#     # This field needs to be set for local storage services like MinIO.
 #     s3Url: http://minio.velero.svc:9000
+#
+#     # You can specify the multipart_chunksize  here for explicitness.
+#     # Minimum value can be set is 5Mi (5*1024*1024 Bytes).. expected value (5Mi/Gi)
+#     # If not set then it will be calculated from the file size
+#     multiPartChunkSize: 64Mi
 
 # ---
 # apiVersion: velero.io/v1
@@ -83,4 +97,11 @@ spec:
 #     bucket: openebs-velero-example
 #     prefix: cstor
 #     provider: aws
+#
+#     # The AWS region where the bucket is located.
 #     region: ap-south-1
+#
+#     # You can specify the multipart_chunksize  here for explicitness.
+#     # Minimum value can be set is 5Mi (5*1024*1024 Bytes).. expected value (5Mi/Gi)
+#     # If not set then it will be calculated from the file size
+#     multiPartChunkSize: 64Mi

--- a/pkg/clouduploader/conn.go
+++ b/pkg/clouduploader/conn.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"gocloud.dev/blob"
@@ -287,5 +288,9 @@ func getPartSize(config map[string]string) (val int64, err error) {
 
 	d := resource.MustParse(partSize)
 	val = d.Value()
+
+	if val < s3manager.MinUploadPartSize {
+		err = errors.Errorf("multiPartChunkSize should be more than %v", s3manager.MinUploadPartSize)
+	}
 	return
 }

--- a/pkg/clouduploader/conn.go
+++ b/pkg/clouduploader/conn.go
@@ -29,6 +29,8 @@ import (
 	"gocloud.dev/blob/gcsblob"
 	"gocloud.dev/blob/s3blob"
 	"gocloud.dev/gcp"
+	"google.golang.org/api/googleapi"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (
@@ -67,6 +69,9 @@ const (
 
 	// AWSSsl if ssl needs to be enabled
 	AWSSsl = "DisableSSL"
+
+	// MultiPartChunkSize is chunk size in case of multi-part upload of individual files
+	MultiPartChunkSize = "multiPartChunkSize"
 )
 
 // Conn defines resource used for cloud related operation
@@ -94,6 +99,9 @@ type Conn struct {
 
 	// file represent remote file name
 	file string
+
+	// partSize for multi-part upload, default value 5MB for AWS (8MB for GCP)
+	partSize int64
 
 	// exitServer, if server connection needs to be stopped or not
 	ExitServer bool
@@ -123,6 +131,9 @@ func (c *Conn) setupGCP(ctx context.Context, bucket string, config map[string]st
 	if err != nil {
 		return nil, err
 	}
+
+	// For GCP we will use default chunk size only since uploader is not using multi-part
+	c.partSize = googleapi.DefaultUploadChunkSize
 	return gcsblob.OpenBucket(ctx, d, bucket, nil)
 }
 
@@ -160,6 +171,13 @@ func (c *Conn) setupAWS(ctx context.Context, bucketName string, config map[strin
 		}
 	}
 
+	pSize, err := getPartSize(config)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid multiPartChunkSize")
+	}
+	// if partSize is 0 then it will be calculated from file size
+	c.partSize = pSize
+
 	s := session.Must(session.NewSession(awsconfig))
 	return s3blob.OpenBucket(ctx, s, bucketName, nil)
 }
@@ -167,24 +185,28 @@ func (c *Conn) setupAWS(ctx context.Context, bucketName string, config map[strin
 // Init initialize connection to cloud blob storage
 func (c *Conn) Init(config map[string]string) error {
 	provider, ok := config[PROVIDER]
+
 	if !ok {
 		return errors.New("Failed to get provider name")
 	}
 	c.provider = provider
 
 	bucketName, ok := config[BUCKET]
+
 	if !ok {
 		return errors.New("Failed to get bucket name")
 	}
 	c.bucketname = bucketName
 
 	prefix, ok := config[PREFIX]
+
 	if !ok {
 		prefix = ""
 	}
 	c.prefix = prefix
 
 	backupPathPrefix, ok := config[BackupPathPrefix]
+
 	if !ok {
 		backupPathPrefix = ""
 	}
@@ -206,7 +228,7 @@ func (c *Conn) Create(opType ServerOperation) ReadWriter {
 	}
 	switch opType {
 	case OpBackup:
-		w, err := c.bucket.NewWriter(c.ctx, c.file, nil)
+		w, err := c.bucket.NewWriter(c.ctx, c.file, &blob.WriterOptions{BufferSize: int(c.partSize)})
 		if err != nil {
 			c.Log.Errorf("Failed to obtain writer: %s", err.Error())
 			return nil
@@ -249,4 +271,21 @@ func (c *Conn) Destroy(rw ReadWriter, opType ServerOperation) {
 		}
 		return
 	}
+}
+
+func getPartSize(config map[string]string) (val int64, err error) {
+	partSize, ok := config[MultiPartChunkSize]
+	if !ok {
+		return
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.Errorf("failed to parse '%s'", partSize)
+		}
+	}()
+
+	d := resource.MustParse(partSize)
+	val = d.Value()
+	return
 }


### PR DESCRIPTION
Changes: 
- Added support for multiPartChunkSize for remote storage services like s3/minio.
By default value of `multiPartChunkSize` is minimum 5MB and it will be adjusted by the plugin according to volume size unless explicitly set in `volumesnapshotlocations`.

For S3 base storage, Velero-plugin uses multipart upload for snapshot backup. `multiPartChunkSize` for the part upload will be minimum 5 MB. https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html
https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html

This value can be increased to avoid performance degradation in case of large number of parts(>500). https://github.com/minio/minio/issues/7206

To configure `VolumeSnapshotLocations` with `multiPartChunkSize`:
```
  spec:
    config:
      bucket: velero
      multiPartChunkSize: 10Mi
      provider: aws
      region: minio
      s3ForcePathStyle: "true"
      s3Url: http://minio.velero.svc:9000
    provider: openebs.io/cstor-blockstore
```
- Added examples under `example/06-volumesnapshotlocation.yaml`

This changes have been tested locally by configuring  `volumesnapshotlocation`   with 
`multiPartChunkSize: 10Mi`
Sample output from minio:
```
/storage/.minio.sys/multipart/23ff86bd6f0e7223de4952ea0d4027d1a8e941da2ed2f40eaf27aa15a86cb519/14c622c4-ee6b-4e51-a188-ac85cf22ad56 # ls -lh
total 830M   
-rw-r--r--    1 root     root       10.0M Mar 27 13:55 00001.b9543c5b785165f98d439b2ba7c48abc.10485760
-rw-r--r--    1 root     root       10.0M Mar 27 13:55 00002.3f8b95e5a434026cbee172ea69ba6819.10485760
-rw-r--r--    1 root     root       10.0M Mar 27 13:55 00003.97af4a5b109786418913e0faf9d91d26.10485760
-rw-r--r--    1 root     root       10.0M Mar 27 13:56 00004.1c266cd1d185b62ef71d97a564c2072b.10485760
-rw-r--r--    1 root     root       10.0M Mar 27 13:56 00005.f00a31f9bd795f7bdfb77d62d79122bc.10485760
-rw-r--r--    1 root     root       10.0M Mar 27 13:56 00006.5d0aed7c0459d7bcdb535bdf3ab16fad.10485760
```
fix: https://github.com/openebs/openebs/issues/2973

Signed-off-by: mayank <mayank.patel@mayadata.io>