### PR TITLE
 feat(cstorBackup, delete): support for snapshot deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ defaultbackup       Completed   2019-05-09 17:08:41 +0530 IST   26d       gcp   
 ```
 Once the backup is completed you should see the backup marked as `Completed`.
 
+*Note:*
+- _If backup name ends with "-20190513104034" format then it is considered as part of scheduled backup_
+
 
 ### Creating a restore from backup
 #### Creating a restore from local backup/snapshot
@@ -173,6 +176,9 @@ newschedule     Enabled   2019-05-13 15:15:39 +0530 IST   */5 * * * *   720h0m0s
 ```
 
 During the first backup iteration of a schedule, full data of the volume will be backed up. For later backup iterations of a schedule, only modified or new data from the previous iteration will be backed up.
+
+*Note:*
+- _If backup name ends with "-20190513104034" format then it is considered as part of scheduled backup_
 
 ### Restoring from a scheduled backup
 #### Restoring from a scheduled local backup/snapshot

--- a/example/06-volumesnapshotlocation.yaml
+++ b/example/06-volumesnapshotlocation.yaml
@@ -42,7 +42,8 @@ spec:
 
 
 ### Sample VolumeSnapshotLocation YAML for various cloud-providers
-# ---
+# # For GCP
+#---
 # apiVersion: velero.io/v1
 # kind: VolumeSnapshotLocation
 # metadata:
@@ -55,29 +56,31 @@ spec:
 #     prefix: cstor
 #     provider: gcp
 
+#
+# # For MinIO
 # ---
 # apiVersion: velero.io/v1
 # kind: VolumeSnapshotLocation
 # metadata:
-#   name: minio-bucket
+#   name: minio
 #   namespace: velero
 # spec:
 #   provider: openebs.io/cstor-blockstore
 #   config:
 #     bucket: openebs-velero-example
+#
 #     prefix: cstor
+#
 #     provider: aws
 #
-#     # The AWS region where the bucket is located.
+#     # The region where the server is located.
 #     region: minio
 #
 #     # Whether to use path-style addressing instead of virtual hosted bucket addressing.
 #     # Set to "true"
-#     # if using a local storage service like MinIO.
 #     s3ForcePathStyle: "true"
 #
-#     # AWS S3 URL, By default it will be generated from "region" and "bucket"
-#     # This field needs to be set for local storage services like MinIO.
+#     # S3 URL, By default it will be generated from "region" and "bucket"
 #     s3Url: http://minio.velero.svc:9000
 #
 #     # You can specify the multipart_chunksize  here for explicitness.
@@ -85,6 +88,8 @@ spec:
 #     # If not set then it will be calculated from the file size
 #     multiPartChunkSize: 64Mi
 
+#
+# # For AWS
 # ---
 # apiVersion: velero.io/v1
 # kind: VolumeSnapshotLocation
@@ -95,7 +100,9 @@ spec:
 #   provider: openebs.io/cstor-blockstore
 #   config:
 #     bucket: openebs-velero-example
+#
 #     prefix: cstor
+#
 #     provider: aws
 #
 #     # The AWS region where the bucket is located.

--- a/example/06-volumesnapshotlocation.yaml
+++ b/example/06-volumesnapshotlocation.yaml
@@ -84,7 +84,8 @@ spec:
 #     s3Url: http://minio.velero.svc:9000
 #
 #     # You can specify the multipart_chunksize  here for explicitness.
-#     # Minimum value can be set is 5Mi (5*1024*1024 Bytes).. expected value (5Mi/Gi)
+#     # multiPartChunkSize can be from 5Mi(5*1024*1024 Bytes) to 5Gi
+#     # For more information: https://docs.min.io/docs/minio-server-limits-per-tenant.html
 #     # If not set then it will be calculated from the file size
 #     multiPartChunkSize: 64Mi
 
@@ -109,6 +110,7 @@ spec:
 #     region: ap-south-1
 #
 #     # You can specify the multipart_chunksize  here for explicitness.
-#     # Minimum value can be set is 5Mi (5*1024*1024 Bytes).. expected value (5Mi/Gi)
+#     # multiPartChunkSize can be from 5Mi(5*1024*1024 Bytes) to 5Gi
+#     # For more information: https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
 #     # If not set then it will be calculated from the file size
 #     multiPartChunkSize: 64Mi

--- a/example/06-volumesnapshotlocation.yaml
+++ b/example/06-volumesnapshotlocation.yaml
@@ -67,9 +67,23 @@ spec:
 #     bucket: openebs-velero-example
 #     prefix: cstor
 #     provider: aws
+#
+#     # The AWS region where the bucket is located.
 #     region: minio
+#
+#     # Whether to use path-style addressing instead of virtual hosted bucket addressing.
+#     # Set to "true"
+#     # if using a local storage service like MinIO.
 #     s3ForcePathStyle: "true"
+#
+#     # AWS S3 URL, By default it will be generated from "region" and "bucket"
+#     # This field needs to be set for local storage services like MinIO.
 #     s3Url: http://minio.velero.svc:9000
+#
+#     # You can specify the multipart_chunksize  here for explicitness.
+#     # Minimum value can be set is 5Mi (5*1024*1024 Bytes).. expected value (5Mi/Gi)
+#     # If not set then it will be calculated from the file size
+#     multiPartChunkSize: 64Mi
 
 # ---
 # apiVersion: velero.io/v1
@@ -83,4 +97,11 @@ spec:
 #     bucket: openebs-velero-example
 #     prefix: cstor
 #     provider: aws
+#
+#     # The AWS region where the bucket is located.
 #     region: ap-south-1
+#
+#     # You can specify the multipart_chunksize  here for explicitness.
+#     # Minimum value can be set is 5Mi (5*1024*1024 Bytes).. expected value (5Mi/Gi)
+#     # If not set then it will be calculated from the file size
+#     multiPartChunkSize: 64Mi

--- a/pkg/clouduploader/conn.go
+++ b/pkg/clouduploader/conn.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"gocloud.dev/blob"
@@ -287,5 +288,9 @@ func getPartSize(config map[string]string) (val int64, err error) {
 
 	d := resource.MustParse(partSize)
 	val = d.Value()
+
+	if val < s3manager.MinUploadPartSize {
+		err = errors.Errorf("multiPartChunkSize should be more than %v", s3manager.MinUploadPartSize)
+	}
 	return
 }

--- a/pkg/clouduploader/conn.go
+++ b/pkg/clouduploader/conn.go
@@ -274,6 +274,10 @@ func (c *Conn) Destroy(rw ReadWriter, opType ServerOperation) {
 	}
 }
 
+// getPartSize returns the multiPartChunkSize from the config
+// - if multiPartChunkSize is not specified then it will return 0
+// - if multiPartChunkSize is less then s3manager.MinUploadPartSize/5Mb then it will return an error
+// - if multiPartChunkSize is invalid then it will return an error
 func getPartSize(config map[string]string) (val int64, err error) {
 	partSize, ok := config[MultiPartChunkSize]
 	if !ok {

--- a/pkg/clouduploader/conn.go
+++ b/pkg/clouduploader/conn.go
@@ -29,6 +29,8 @@ import (
 	"gocloud.dev/blob/gcsblob"
 	"gocloud.dev/blob/s3blob"
 	"gocloud.dev/gcp"
+	"google.golang.org/api/googleapi"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (
@@ -67,6 +69,9 @@ const (
 
 	// AWSSsl if ssl needs to be enabled
 	AWSSsl = "DisableSSL"
+
+	// MultiPartChunkSize is chunk size in case of multi-part upload of individual files
+	MultiPartChunkSize = "multiPartChunkSize"
 )
 
 // Conn defines resource used for cloud related operation
@@ -94,6 +99,9 @@ type Conn struct {
 
 	// file represent remote file name
 	file string
+
+	// partSize for multi-part upload, default value 5MB for AWS (8MB for GCP)
+	partSize int64
 
 	// exitServer, if server connection needs to be stopped or not
 	ExitServer bool
@@ -123,6 +131,9 @@ func (c *Conn) setupGCP(ctx context.Context, bucket string, config map[string]st
 	if err != nil {
 		return nil, err
 	}
+
+	// For GCP we will use default chunk size only since uploader is not using multi-part
+	c.partSize = googleapi.DefaultUploadChunkSize
 	return gcsblob.OpenBucket(ctx, d, bucket, nil)
 }
 
@@ -160,6 +171,13 @@ func (c *Conn) setupAWS(ctx context.Context, bucketName string, config map[strin
 		}
 	}
 
+	pSize, err := getPartSize(config)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid multiPartChunkSize")
+	}
+	// if partSize is 0 then it will be calculated from file size
+	c.partSize = pSize
+
 	s := session.Must(session.NewSession(awsconfig))
 	return s3blob.OpenBucket(ctx, s, bucketName, nil)
 }
@@ -167,24 +185,28 @@ func (c *Conn) setupAWS(ctx context.Context, bucketName string, config map[strin
 // Init initialize connection to cloud blob storage
 func (c *Conn) Init(config map[string]string) error {
 	provider, ok := config[PROVIDER]
+
 	if !ok {
 		return errors.New("Failed to get provider name")
 	}
 	c.provider = provider
 
 	bucketName, ok := config[BUCKET]
+
 	if !ok {
 		return errors.New("Failed to get bucket name")
 	}
 	c.bucketname = bucketName
 
 	prefix, ok := config[PREFIX]
+
 	if !ok {
 		prefix = ""
 	}
 	c.prefix = prefix
 
 	backupPathPrefix, ok := config[BackupPathPrefix]
+
 	if !ok {
 		backupPathPrefix = ""
 	}
@@ -206,7 +228,7 @@ func (c *Conn) Create(opType ServerOperation) ReadWriter {
 	}
 	switch opType {
 	case OpBackup:
-		w, err := c.bucket.NewWriter(c.ctx, c.file, nil)
+		w, err := c.bucket.NewWriter(c.ctx, c.file, &blob.WriterOptions{BufferSize: int(c.partSize)})
 		if err != nil {
 			c.Log.Errorf("Failed to obtain writer: %s", err.Error())
 			return nil
@@ -249,4 +271,21 @@ func (c *Conn) Destroy(rw ReadWriter, opType ServerOperation) {
 		}
 		return
 	}
+}
+
+func getPartSize(config map[string]string) (val int64, err error) {
+	partSize, ok := config[MultiPartChunkSize]
+	if !ok {
+		return
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.Errorf("failed to parse '%s'", partSize)
+		}
+	}()
+
+	d := resource.MustParse(partSize)
+	val = d.Value()
+	return
 }

--- a/pkg/clouduploader/operation.go
+++ b/pkg/clouduploader/operation.go
@@ -27,7 +27,7 @@ const (
 // It will create a TCP server through which client can
 // connect and upload data to cloud blob storage file
 func (c *Conn) Upload(file string, fileSize int64) bool {
-	c.Log.Infof("Uploading snapshot to  '%s' with provider{%s} to bucket{%s}", file, c.provider, c.bucketname)
+	c.Log.Infof("Uploading snapshot to '%s' with provider{%s} to bucket{%s}", file, c.provider, c.bucketname)
 
 	c.file = file
 	if c.partSize == 0 {
@@ -59,7 +59,7 @@ func (c *Conn) Upload(file string, fileSize int64) bool {
 
 // Delete will delete file from cloud blob storage
 func (c *Conn) Delete(file string) bool {
-	c.Log.Infof("Removing snapshot:'%s' from bucket{%s} provider{%s}", file, c.bucket, c.provider)
+	c.Log.Infof("Removing snapshot:'%s' from bucket{%s} provider{%s}", file, c.bucketname, c.provider)
 
 	if c.bucket.Delete(c.ctx, file) != nil {
 		c.Log.Errorf("Failed to remove snapshot{%s} from cloud", file)

--- a/pkg/cstor/cstor.go
+++ b/pkg/cstor/cstor.go
@@ -517,7 +517,7 @@ func (p *Plugin) getScheduleName(backupName string) string {
 	// If it is scheduled backup then we need to get the schedule name
 	splitName := strings.Split(backupName, "-")
 	if len(splitName) >= 2 {
-		t, err := time.Parse("20060102150405", splitName[len(splitName)-1])
+		_, err := time.Parse("20060102150405", splitName[len(splitName)-1])
 		if err != nil {
 			// last substring is not timestamp, so it is not generated from schedule
 			return scheduleOrBackupName

--- a/pkg/cstor/cstor.go
+++ b/pkg/cstor/cstor.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	cloud "github.com/openebs/velero-plugin/pkg/clouduploader"
 	"github.com/pkg/errors"
@@ -508,14 +509,20 @@ func (p *Plugin) getVolInfo(volumeID, snapName string) (*Volume, error) {
 }
 
 // getScheduleName return the schedule name for the given backup
+// It will check if backup name have 'bkp-20060102150405' format
 func (p *Plugin) getScheduleName(backupName string) string {
 	// for non-scheduled backup, we are considering backup name as schedule name only
-	scheduleName := backupName
+	scheduleOrBackupName := backupName
 
 	// If it is scheduled backup then we need to get the schedule name
 	splitName := strings.Split(backupName, "-")
 	if len(splitName) >= 2 {
-		scheduleName = strings.Join(splitName[0:len(splitName)-1], "-")
+		t, err := time.Parse("20060102150405", splitName[len(splitName)-1])
+		if err != nil {
+			// last substring is not timestamp, so it is not generated from schedule
+			return scheduleOrBackupName
+		}
+		scheduleOrBackupName = strings.Join(splitName[0:len(splitName)-1], "-")
 	}
-	return scheduleName
+	return scheduleOrBackupName
 }

--- a/pkg/cstor/status.go
+++ b/pkg/cstor/status.go
@@ -156,14 +156,6 @@ func isScheduledBackup(bkp v1alpha1.CStorBackup) bool {
 	return false
 }
 
-// isBackupFailed returns true if backup failed
-func isBackupFailed(bkp v1alpha1.CStorBackup) bool {
-	if bkp.Status == v1alpha1.BKPCStorStatusFailed || bkp.Status == v1alpha1.BKPCStorStatusInvalid {
-		return true
-	}
-	return false
-}
-
 // isBackupSucceeded returns true if backup completed successfully
 func isBackupSucceeded(bkp v1alpha1.CStorBackup) bool {
 	if bkp.Status == v1alpha1.BKPCStorStatusDone {

--- a/pkg/cstor/status.go
+++ b/pkg/cstor/status.go
@@ -119,9 +119,15 @@ func (p *Plugin) checkRestoreStatus(rst *v1alpha1.CStorRestore, vol *Volume) {
 //		- if current backup is failed then it will delete the current backup
 func (p *Plugin) cleanupCompletedBackup(bkp v1alpha1.CStorBackup) error {
 	targetedSnapName := bkp.Spec.SnapName
+
+	// In case of scheduled backup we are using the last completed backup to send
+	// differential snapshot. So We don't need to delete the last completed backup.
 	if isScheduledBackup(bkp) && isBackupSucceeded(bkp) {
-		// if current backup is first backup of schedule then skip the clean-up
+		// For incremental backup We are using PrevSnapName to send the differential snapshot
+		// Since Given backup is completed successfully We can delete the 2nd last completed backup
 		if len(bkp.Spec.PrevSnapName) == 0 {
+			// PrevSnapName will be empty if the given backup is base backup
+			// clean-up is not required for base backup
 			return nil
 		}
 		targetedSnapName = bkp.Spec.PrevSnapName

--- a/pkg/cstor/status.go
+++ b/pkg/cstor/status.go
@@ -113,10 +113,11 @@ func (p *Plugin) checkRestoreStatus(rst *v1alpha1.CStorRestore, vol *Volume) {
 
 // cleanupCompletedBackup send the delete request to apiserver
 // to cleanup backup resources
-// If it is normal backup then it will delete the current backup
+// If it is normal backup then it will delete the current backup, it can be failed or succeeded backup
 // If it is scheduled backup then
-//		- if current backup is succeeded then it will delete the previous backup
-//		- if current backup is failed then it will delete the current backup
+//		- if current backup is base backup, not incremental one, then it will not perform any clean-up
+//		- if current backup is incremental backup and failed one then it will delete that(current) backup
+//		- if current backup is incremental backup and completed successfully then it will delete the last completed or previous backup
 func (p *Plugin) cleanupCompletedBackup(bkp v1alpha1.CStorBackup) error {
 	targetedSnapName := bkp.Spec.SnapName
 

--- a/tests/k8s/log.go
+++ b/tests/k8s/log.go
@@ -38,11 +38,14 @@ func (k *KubeClient) DumpLogs(ns, podName, container string) error {
 
 	readCloser, err := req.Stream()
 	if err != nil {
-		fmt.Printf("DumpLogs: Error occured for %s/%s:%s.. %s", ns, podName, container, err)
+		fmt.Printf("DumpLogs: Error occurred for %s/%s:%s.. %s", ns, podName, container, err)
 		return err
 	}
 
-	defer readCloser.Close()
+	defer func() {
+		_ = readCloser.Close()
+	}()
+
 	_, err = io.Copy(os.Stdout, readCloser)
 	fmt.Println(err)
 	return err

--- a/tests/openebs/storage_status.go
+++ b/tests/openebs/storage_status.go
@@ -18,6 +18,7 @@ package openebs
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	v1alpha1 "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
@@ -169,4 +170,72 @@ func getPoolNameFromCVR(k v1alpha1.CStorVolumeReplica) string {
 
 func getVolumeNameFromCVR(k v1alpha1.CStorVolumeReplica) string {
 	return k.Labels[cVRPVLabel]
+}
+
+// GetCStorBackups returns cstorbackup list for the given backup
+func (c *ClientSet) GetCStorBackups(backup, ns string) (*v1alpha1.CStorBackupList, error) {
+	return c.OpenebsV1alpha1().
+		CStorBackups(ns).
+		List(metav1.ListOptions{
+			LabelSelector: "openebs.io/backup=" + backup,
+		})
+}
+
+// GetCStorCompletedBackups returns cstorcompletedbackup list for the given backup
+func (c *ClientSet) GetCStorCompletedBackups(backup, ns string) (*v1alpha1.CStorCompletedBackupList, error) {
+	return c.OpenebsV1alpha1().
+		CStorCompletedBackups(ns).
+		List(metav1.ListOptions{
+			LabelSelector: "openebs.io/backup=" + backup,
+		})
+}
+
+// IsBackupResourcesExist checks if backupResources, for the given backup, exist or not
+func (c *ClientSet) IsBackupResourcesExist(backup, pvc, ns string) (bool, error) {
+	isSchedule := false
+	isLastBackup := false
+
+	scheduleName := backup
+	splitName := strings.Split(backup, "-")
+	if len(splitName) >= 2 {
+		isSchedule = true
+		scheduleName = strings.Join(splitName[0:len(splitName)-1], "-")
+	}
+
+	blist, err := c.GetCStorBackups(scheduleName, ns)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to fetch cstorbackup list for backup %s/%s", ns, backup)
+	}
+
+	cblist, err := c.GetCStorCompletedBackups(scheduleName, ns)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to fetch cstorcompletedbackup list for backup %s/%s", ns, backup)
+	}
+
+	if isSchedule && len(cblist.Items) == 1 {
+		cbkp := cblist.Items[0]
+		// if given backup is the last backup then relevant  cstorbackup will not be deleted
+		for i, bkp := range blist.Items {
+			if bkp.Spec.SnapName == cbkp.Spec.PrevSnapName {
+				blist.Items = append(blist.Items[:i], blist.Items[i+1:]...)
+			}
+			if bkp.Spec.SnapName == backup {
+				isLastBackup = true
+			}
+		}
+		cblist.Items = cblist.Items[:0]
+	}
+
+	snapshotExist, err := c.CheckSnapshot(pvc, ns, backup)
+	if err != nil {
+		if !strings.Contains(err.Error(), "command terminated with exit code 1") {
+			return false, errors.Wrapf(err, "failed to verify snapshot for backup %s/%s", ns, backup)
+		}
+	}
+
+	if len(blist.Items) != 0 || len(cblist.Items) != 0 || (snapshotExist && !isLastBackup) {
+		return true, errors.Errorf("backup %s/%s backup:%d cbackup:%d snapshot:%v isLastBackup:%v", ns, backup, len(blist.Items), len(cblist.Items), snapshotExist, isLastBackup)
+	}
+
+	return false, nil
 }

--- a/tests/openebs/storage_status.go
+++ b/tests/openebs/storage_status.go
@@ -212,6 +212,11 @@ func (c *ClientSet) IsBackupResourcesExist(backup, pvc, ns string) (bool, error)
 		return false, errors.Wrapf(err, "failed to fetch cstorcompletedbackup list for backup %s/%s", ns, backup)
 	}
 
+	if isSchedule && len(cblist.Items) == 0 {
+		return true, errors.Errorf("for schedule cstorcompletedbackups should be present")
+	}
+
+	// for schedule cstorcompletedbackups is not deleted by apiserver to support incremental backup
 	if isSchedule && len(cblist.Items) == 1 {
 		cbkp := cblist.Items[0]
 		// if given backup is the last backup then relevant  cstorbackup will not be deleted

--- a/tests/sanity/backup_test.go
+++ b/tests/sanity/backup_test.go
@@ -87,6 +87,9 @@ var _ = Describe("Backup/Restore Test", func() {
 			}
 			Expect(err).NotTo(HaveOccurred())
 			Expect(status).To(Equal(v1.BackupPhaseCompleted))
+			isExist, err := openebs.Client.IsBackupResourcesExist(backupName, app.PVCName, AppNs)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isExist).To(BeFalse())
 		})
 	})
 
@@ -100,6 +103,15 @@ var _ = Describe("Backup/Restore Test", func() {
 			Expect(status).To(Equal(v1.BackupPhaseCompleted))
 			err = velero.Client.DeleteSchedule(scheduleName)
 			Expect(err).NotTo(HaveOccurred())
+
+			bkplist, err := velero.Client.GetScheduledBackups(scheduleName)
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, bkp := range bkplist {
+				isExist, err := openebs.Client.IsBackupResourcesExist(bkp, app.PVCName, AppNs)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isExist).To(BeFalse())
+			}
 		})
 	})
 
@@ -167,5 +179,4 @@ var _ = Describe("Backup/Restore Test", func() {
 			}
 		})
 	})
-
 })


### PR DESCRIPTION
Changes:
- This PR adds support to cleanup backup resources generated by maya-apiserver, to execute backup of CStor volumes.

Velero-plugin will execute clean-up operation in following scenarios:
- In case of normal backup, Plugin will send delete request to api-server once the backup for the cstor volume completes
- In case of scheduled backup, Plugin will send delete request, for second-last completed backup, to api-server.
- If backup, normal or scheduled,  is failed then plugin will send the delete request to api-server.

- In case of scheduled backup, 
               A) If backup is last generated one then Maya-Apiserver will delete the relevant CStorBackup, CStorCompletedBackups and CStor snapshot, so next new backup will be full backup
               B) If backup is not the last one then maya-apiserver will delete the relevant CStorBackup and CStor snapshot


REST API query format:
`<APISERVER_ADDR>/latest/backups/<BACKUP_NAME>?volume=<VOL_NAME>&namespace=<PVC_NAMESPACE>&schedule=<SCHEDULE_NAME>`

Sample query URL:
`http://10.0.0.94:5656/latest/backups/emyqevym-20200401174441?volume=pvc-165d0f86-7441-11ea-9d2c-d89c67d5e4a1&namespace=app&schedule=emyqevym`

Covered test cases :
1. Test to verify clean-up of CStorBackup, CStorCompletedBackups and CStor snapshot in case of normal backup
2. Test to verify clean-up of CStorBackup, CStorCompletedBackups and CStor snapshot in case of scheduled backup

Depends on: https://github.com/openebs/maya/pull/1644
Fixes: https://github.com/openebs/openebs/issues/2957