### PR TITLE
chore(travis): updating travis file according to new release format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,15 +30,12 @@ script:
   - make container
   - kubectl cluster-info
   - |
-    vR=`echo $TRAVIS_BRANCH |awk -F 'velero_'  '{print $2}'`
-    if [ -z $TRAVIS_BRANCH ] || [ $TRAVIS_BRANCH == "master" ] || [ -z $vR ]; then
-      export VELERO_RELEASE=v1.0.0
-      # In travis we use openebs operator from openebs/openebs:master only.
-      export OPENEBS_RELEASE="master"
+    export VELERO_RELEASE=v1.0.0
+    if [ ! -z $TRAVIS_TAG ]; then
+      export OPENEBS_RELEASE=${TRAVIS_TAG}
     else
-      export VELERO_RELEASE=v${vR}
-      oR=`echo $TRAVIS_BRANCH |awk -F '-' '{print $1}'`
-      export OPENEBS_RELEASE=${oR}
+      # In travis we use openebs operator from openebs/openebs:master only.
+      export OPENEBS_RELEASE=master
     fi
   - ./script/install-openebs.sh
   - ./script/install-velero.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,13 @@ script:
   - kubectl cluster-info
   - |
     export VELERO_RELEASE=v1.0.0
-    if [ ! -z $TRAVIS_TAG ]; then
-      export OPENEBS_RELEASE=${TRAVIS_TAG}
-    else
-      # In travis we use openebs operator from openebs/openebs:master only.
-      export OPENEBS_RELEASE=master
-    fi
+    # In travis we use openebs operator from openebs/openebs:master only.
+    export OPENEBS_RELEASE=master
+    #if [ ! -z $TRAVIS_TAG ]; then
+    #  export OPENEBS_RELEASE=${TRAVIS_TAG}
+    #else
+    #  export OPENEBS_RELEASE=master
+    #fi
   - ./script/install-openebs.sh
   - ./script/install-velero.sh
   - travis_wait make test


### PR DESCRIPTION
velero-plugin will be using the tag format same as `openebs/maya`. Due to that we need to update the travis file which was using the old format `1.3.0-RC1-velero_1.0.0`. 
As of now velero-plugin BDD is using golang code for testing instead of velero binaries. For testing code we are using velero code base v1.0.0 only. Testing multiple version is not feasible since it requires multiple copies of the testing code, so we will continue BDD with v1.0.0 until we update the testing code to use v1.3.0.
 
Signed-off-by: mayank <mayank.patel@mayadata.io>