### PR TITLE
feat(multiple-s3): support for multiple s3 profile

### DIFF
--- a/changelogs/unreleased/76-mynktl
+++ b/changelogs/unreleased/76-mynktl
@@ -1,0 +1,1 @@
+Adding support for multiple s3 profile to backup cstor volumes to different s3 location

--- a/example/06-volumesnapshotlocation.yaml
+++ b/example/06-volumesnapshotlocation.yaml
@@ -76,6 +76,9 @@ spec:
 #     # The region where the server is located.
 #     region: minio
 #
+#     # profile for credential, if not mentioned then plugin will use profile=default
+#     profile: user1
+#
 #     # Whether to use path-style addressing instead of virtual hosted bucket addressing.
 #     # Set to "true"
 #     s3ForcePathStyle: "true"
@@ -108,6 +111,9 @@ spec:
 #
 #     # The AWS region where the bucket is located.
 #     region: ap-south-1
+#
+#     # profile for credential, if not mentioned then plugin will use profile=default
+#     profile: user1
 #
 #     # You can specify the multipart_chunksize  here for explicitness.
 #     # multiPartChunkSize can be from 5Mi(5*1024*1024 Bytes) to 5Gi


### PR DESCRIPTION
Changes:
- Added support for multiple s3 profiles for volumesnapshotlocation.
- Removed call to get secret file using `AWS_SHARED_CREDENTIALS_FILE` since it is handled by sdk itself

fixes: https://github.com/openebs/velero-plugin/issues/58

Changes were tested locally using multiple s3 profile. Scenarios tested:
- Having two profile, default and prof1 and no profile in VSL
          - backup/restore passed
- Having two profile, prof1 and prof2 -- VSL configured with profile `prof1`
         - backup/restore passed
- Having two profile, prof1 and prof2 -- no profile in VSL
         - backup/restore failed
- Having two profile, default and prof2 -- VSL configured with profile `prof1`
        - backup/restore failed

Signed-off-by: mayank <mayank.patel@mayadata.io>
