### PR TITLE
fix(snapshotID): empty check for snapshotID

### DIFF
--- a/changelogs/unreleased/79-mynktl
+++ b/changelogs/unreleased/79-mynktl
@@ -1,0 +1,1 @@
+Fixed panic, created because of empty snapshotID, while deleting failed backup


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
This PR is fix for [bug](https://github.com/openebs/velero-plugin/issues/78) 

**What this PR does?**:
This PR add a check in delete snapshot API of plugin to verify if `snapshotID` is empty or not.
This PR also add additional check for `snapshotID` verification in `getInfoFromSnapshotID`, used for getting information about volume and backup name.

**Does this PR require any upgrade changes?**:
No.

**If the changes in this PR are manually verified, list down the scenarios covered and commands you used for testing with logs:**
- deletion of failed backup with empty snapshotID
    - deletion completes with warning message
```
time="2020-05-07T07:59:52Z" level=warning msg="Empty snapshotID" backup=b5 cmd=/plugins/velero-blockstore-cstor controller=backup-deletion logSource="/home/mayank/go/src/github.com/openebs/velero-plugin/pkg/cstor/cstor.go:274" name=b5-pm92l namespace=velero pluginName=velero-blockstore-cstor
``
- restore of failed backup with empty snapshotID
    - restore for PV snapshot didn't trigger due to empty snapshotID

**Checklist:**
- [ ] Fixes #https://github.com/openebs/velero-plugin/issues/78
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>` : yes
- [ ] Has the change log section been updated? : yes
- [ ] Commit has unit tests : no
- [ ] Commit has integration tests : no

Signed-off-by: mayank <mayank.patel@mayadata.io>
