### PR TITLE
refact(build): make the docker images configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,35 @@
+# Copyright 2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Dockerfile builds velero-plugin
+
 FROM alpine:3.10.4
 RUN mkdir /plugins
 ADD velero-* /plugins/
 USER nobody:nobody
 
+ARG ARCH
 ARG BUILD_DATE
-LABEL org.label-schema.build-date=$BUILD_DATE
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="velero-plugin"
+LABEL org.label-schema.description="OpenEBS velero-plugin"
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
 
 ENTRYPOINT ["/bin/ash", "-c", "cp /plugins/* /target/."]

--- a/push
+++ b/push
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+# Copyright 2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
 if [ -z ${DIMAGE} ];
@@ -42,7 +57,10 @@ function TagAndPushImage() {
   REPO="$1"
   TAG="$2"
 
-  IMAGE_URI="${REPO}:${TAG}";
+  #Add an option to specify a custom TAG_SUFFIX
+  #via environment variable. Default is no tag.
+  #Example suffix could be "-debug" of "-dev"
+  IMAGE_URI="${REPO}:${TAG}${TAG_SUFFIX}";
   sudo docker tag ${IMAGEID} ${IMAGE_URI};
   echo " push ${IMAGE_URI}";
   sudo docker push ${IMAGE_URI};


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

There are cases where users might want to build and push
container images in their own environments.

**What this PR does?**:

This commit will help customizing docker images via environment variables:
- The following ENV help specify custom docker build args
  - DBUILD_SITE_URL ( default: https://openebs.io )
  - DBUILD_REPO_URL ( default: https://github.com/openebs/node-disk-manager )
- The following ENV allows Travis to specify custom image org
  - IMAGE_ORG (default: openebs )
- The following ENV will allow specifying an extra tag suffix
  - TAG_SUFFIX ( default: none )

**Does this PR require any upgrade changes?**:
No. 

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Used make file commands to create images. 
Travis CI verifies the image generation. 

Signed-off-by: mayank <mayank.patel@mayadata.io>

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on 