### PR TITLE
cherr-pick(fix,restore): removing annotation openebs.io/created-through from PVC

### DIFF
--- a/changelogs/unreleased/85-mynktl
+++ b/changelogs/unreleased/85-mynktl
@@ -1,0 +1,1 @@
+Fixing failure restic backup of cstor volumes, restored by velero-plugin [issue:84](https://github.com/openebs/velero-plugin/issues/84)

--- a/pkg/cstor/pvc_operation.go
+++ b/pkg/cstor/pvc_operation.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"time"
 
+	v1alpha1 "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	velero "github.com/openebs/velero-plugin/pkg/velero"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -117,7 +118,9 @@ func (p *Plugin) createPVC(volumeID, snapName string) (*Volume, error) {
 	p.Log.Infof("Creating PVC for volumeID:%s snapshot:%s in namespace=%s", volumeID, snapName, targetedNs)
 
 	pvc.Annotations = make(map[string]string)
-	pvc.Annotations["openebs.io/created-through"] = "restore"
+	// Add annotation PVCreatedByKey, with value 'restore' to PVC
+	// So that Maya-APIServer skip updating target IPAddress in CVR
+	pvc.Annotations[v1alpha1.PVCreatedByKey] = "restore"
 	rpvc, err := p.K8sClient.
 		CoreV1().
 		PersistentVolumeClaims(pvc.Namespace).
@@ -161,6 +164,15 @@ func (p *Plugin) createPVC(volumeID, snapName string) (*Volume, error) {
 
 	if err = p.waitForAllCVR(vol); err != nil {
 		return nil, err
+	}
+
+	// CVRs are created and updated, now we can remove the annotation 'PVCreatedByKey' from PVC
+	if err = p.removePVCAnnotationKey(pvc, v1alpha1.PVCreatedByKey); err != nil {
+		p.Log.Warningf("Failed to remove restore annotation from PVC=%s/%s err=%s", pvc.Namespace, pvc.Name, err)
+		return nil, errors.Wrapf(err,
+			"failed to clear restore-annotation=%s from PVC=%s/%s",
+			v1alpha1.PVCreatedByKey, pvc.Namespace, pvc.Name,
+		)
 	}
 	return vol, nil
 }
@@ -224,6 +236,17 @@ func (p *Plugin) getVolumeFromPVC(pvc v1.PersistentVolumeClaim) (*Volume, error)
 	if err = p.waitForAllCVR(vol); err != nil {
 		return nil, errors.Wrapf(err, "cvr not ready")
 	}
+
+	// remove the annotation 'PVCreatedByKey' from PVC
+	// There might be chances of stale PVCreatedByKey annotation in PVC
+	if err = p.removePVCAnnotationKey(rpvc, v1alpha1.PVCreatedByKey); err != nil {
+		p.Log.Warningf("Failed to remove restore annotation from PVC=%s/%s err=%s", rpvc.Namespace, rpvc.Name, err)
+		return nil, errors.Wrapf(err,
+			"failed to clear restore-annotation=%s from PVC=%s/%s",
+			v1alpha1.PVCreatedByKey, rpvc.Namespace, rpvc.Name,
+		)
+	}
+
 	return vol, nil
 }
 
@@ -242,4 +265,21 @@ func (p *Plugin) downloadPVC(volumeID, snapName string) (*v1.PersistentVolumeCla
 	}
 
 	return pvc, nil
+}
+
+// removePVCAnnotationKey remove the given annotation key from the PVC and update it
+func (p *Plugin) removePVCAnnotationKey(pvc *v1.PersistentVolumeClaim, annotationKey string) error {
+	var err error
+
+	if pvc.Annotations == nil {
+		return nil
+	}
+
+	delete(pvc.Annotations, annotationKey)
+
+	_, err = p.K8sClient.
+		CoreV1().
+		PersistentVolumeClaims(pvc.Namespace).
+		Update(pvc)
+	return err
 }


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
This PR is fix for https://github.com/openebs/velero-plugin/issues/84 and https://github.com/openebs/maya/issues/1689

**What this PR does?**:
This PR clears the annotation `openebs.io/created-through` from restore cstor PVC.
Cherry-pick of https://github.com/openebs/velero-plugin/pull/85

**Does this PR require any upgrade changes?**: No


**If the changes in this PR are manually verified, list down the scenarios covered and commands you used for testing with logs:**
Following scenario verified
- Created remote backup of percona application, using cstor volume in namespace `test`, through velero-plugin
    - Created restore from that backup in different namespace `ns1`
    - Verified that PVC doesn't have annotation `openebs.io/created-through`
    - Created restic backup for the restored percona application
    - Created restore from that restic backup to different namespace `ns2`

Output:
- List of PVC
```bash
mayank@mayank:~/cloudvm$ kubectl get pvc -A 
NAMESPACE   NAME                       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
ns1         demo-cstor-vol-claim-1     Bound    pvc-d7620526-f982-4cc1-9397-9914a4354dcc   5G         RWO            openebs-cstor-sparse   28m
ns2         demo-cstor-vol-claim-1     Bound    pvc-1245be62-8a12-49b4-b1f2-653995f63613   5G         RWO            openebs-cstor-sparse   4m17s
test        demo-cstor-vol-claim-1     Bound    pvc-4bf06db4-2cba-4c23-998b-f6e3249d4fa6   5G         RWO            openebs-cstor-sparse   96m

```
- List of CVR
```bash
mayank@mayank:~/cloudvm$ kubectl get cvr -n openebs
NAME                                                       USED    ALLOCATED   STATUS    AGE
pvc-1245be62-8a12-49b4-b1f2-653995f63613-cstor-pool-z7ra   36.4M   12.1M       Healthy   4m39s
pvc-4bf06db4-2cba-4c23-998b-f6e3249d4fa6-cstor-pool-z7ra   6.50K   6.50K       Healthy   97m
pvc-d7620526-f982-4cc1-9397-9914a4354dcc-cstor-pool-z7ra   54.7M   16.1M       Healthy   28m
```
- Annotation in CVR
```bash
mayank@mayank:~/cloudvm$ kubectl get cvr pvc-1245be62-8a12-49b4-b1f2-653995f63613-cstor-pool-z7ra   -n openebs  -o json |jq ".metadata.annotations" 
{
  "cstorpool.openebs.io/hostname": "127.0.0.1",
  "isRestoreVol": "false",
  "openebs.io/storage-class-ref": "name: openebs-cstor-sparse\nresourceVersion: 538\n"
}
mayank@mayank:~/cloudvm$ kubectl get cvr pvc-d7620526-f982-4cc1-9397-9914a4354dcc-cstor-pool-z7ra    -n openebs  -o json |jq ".metadata.annotations" 
{
  "cstorpool.openebs.io/hostname": "127.0.0.1",
  "isRestoreVol": "true",
  "openebs.io/storage-class-ref": "name: openebs-cstor-sparse\nresourceVersion: 538\n"
}
mayank@mayank:~/cloudvm$ kubectl get cvr pvc-4bf06db4-2cba-4c23-998b-f6e3249d4fa6-cstor-pool-z7ra     -n openebs  -o json |jq ".metadata.annotations" 
{
  "cstorpool.openebs.io/hostname": "127.0.0.1",
  "isRestoreVol": "false",
  "openebs.io/storage-class-ref": "name: openebs-cstor-sparse\nresourceVersion: 538\n"
}
```
- PVC Annotations
```bash
mayank@mayank:~/cloudvm$ kubectl get pvc demo-cstor-vol-claim-1 -n ns1  -o json |jq ".metadata.annotations" 
{
  "pv.kubernetes.io/bind-completed": "yes",
  "pv.kubernetes.io/bound-by-controller": "yes",
  "volume.beta.kubernetes.io/storage-provisioner": "openebs.io/provisioner-iscsi"
}
mayank@mayank:~/cloudvm$ kubectl get pvc demo-cstor-vol-claim-1 -n ns2  -o json |jq ".metadata.annotations" 
{
  "pv.kubernetes.io/bind-completed": "yes",
  "pv.kubernetes.io/bound-by-controller": "yes",
  "volume.beta.kubernetes.io/storage-provisioner": "openebs.io/provisioner-iscsi"
}
mayank@mayank:~/cloudvm$ kubectl get pvc demo-cstor-vol-claim-1 -n test  -o json |jq ".metadata.annotations" 
{
  "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"PersistentVolumeClaim\",\"metadata\":{\"annotations\":{},\"name\":\"demo-cstor-vol-claim-1\",\"namespace\":\"test\"},\"spec\":{\"accessModes\":[\"ReadWriteOnce\"],\"resources\":{\"requests\":{\"storage\":\"5G\"}},\"storageClassName\":\"openebs-cstor-sparse\"}}\n",
  "pv.kubernetes.io/bind-completed": "yes",
  "pv.kubernetes.io/bound-by-controller": "yes",
  "volume.beta.kubernetes.io/storage-provisioner": "openebs.io/provisioner-iscsi"
}
```

**Checklist:**
- [x] Fixes #https://github.com/openebs/velero-plugin/issues/84 https://github.com/openebs/maya/issues/1689
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

Signed-off-by: mayank <mayank.patel@mayadata.io>
