### PR TITLE
feat(s3): support to use custom certificate for s3 object storage

### DIFF
--- a/changelogs/unreleased/115-mynktl
+++ b/changelogs/unreleased/115-mynktl
@@ -1,0 +1,1 @@
+Added support to use custom certificate and option to skip certificate verification for s3 object storage

--- a/example/06-volumesnapshotlocation.yaml
+++ b/example/06-volumesnapshotlocation.yaml
@@ -91,6 +91,15 @@ spec:
 #     # For more information: https://docs.min.io/docs/minio-server-limits-per-tenant.html
 #     # If not set then it will be calculated from the file size
 #     multiPartChunkSize: 64Mi
+#
+#     # If MinIO is configured with custom certificate then certificate can be passed to plugin through caCert
+#     # Value of caCert must be base64 encoded
+#     # To encode, execute command: cat ca.crt |base64 -w 0
+#     caCert: LS0tLS1CRU...tRU5EIENFUlRJRklDQVRFLS0tLS0K
+#
+#     # If you want to disable certificate verification then set insecureSkipTLSVerify to "true"
+#     # By default insecureSkipTLSVerify is set to "false"
+#     insecureSkipTLSVerify: "false"
 
 #
 # # For AWS
@@ -98,7 +107,7 @@ spec:
 # apiVersion: velero.io/v1
 # kind: VolumeSnapshotLocation
 # metadata:
-#   name: aws-bucket
+#   name: aws
 #   namespace: velero
 # spec:
 #   provider: openebs.io/cstor-blockstore
@@ -120,3 +129,12 @@ spec:
 #     # For more information: https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
 #     # If not set then it will be calculated from the file size
 #     multiPartChunkSize: 64Mi
+#
+#     # if s3 endpoint is configured with custom certificate then certificate can be passed to plugin through caCert.
+#     # Value of caCert must be base64 encoded
+#     # To encode, execute command: cat ca.crt |base64 -w 0
+#     caCert: LS0tLS1CRU...tRU5EIENFUlRJRklDQVRFLS0tLS0K
+#
+#     # If you want to disable certificate verification then set insecureSkipTLSVerify to "true"
+#     # By default insecureSkipTLSVerify is set to "false"
+#     insecureSkipTLSVerify: "false"


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
Fixes: https://github.com/openebs/velero-plugin/issues/113

**What this PR does?**:
This PR add support to pass custom certificate for s3 base object storage. PR also includes changes to disable certificate verification for s3 object storage.
With this PR, following additional fields can be configured in volumesnapshotlocation for s3 base storage:
- caCert
  Base64 encoded certificate data.

- insecureSkipTLSVerify
  Default value is "false". 

**Does this PR require any upgrade changes?**:
No.

**If the changes in this PR are manually verified, list down the scenarios covered and commands you used for testing with logs:**
- MinIO cofigured with custom certificate
  - volumesnapshotlocation configured with caCert
        - backup/restore passed
  - volumesnapshotlocation configured without caCert
        - backup/restore failed with error `error msg="Failed to close cloud conn : blob (code=Unknown): RequestError: send request failed\ncaused by: Put \"https://minio.velero.svc:9000/velero/backups/b3/cstor-pvc-7483f113-6950-4fdb-9686-0cb0d0b33855-b3.pvc\": x509: certificate signed by unknown authority"`

  - volumesnapshotlocation configured with `insecureSkipTLSVerify` set to "true"
        - backup/restore passed

**Any additional information for your reviewer?**:
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #113 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
