### PR TITLE
feat(log): making log level available for velero plugin

### DIFF
--- a/changelogs/116-pawanpraka1
+++ b/changelogs/116-pawanpraka1
@@ -1,0 +1,1 @@
+making log level available for velero plugin

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/prometheus/client_golang v1.5.1 // indirect
 	github.com/sirupsen/logrus v1.5.0
 	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/vmware-tanzu/velero v1.3.2
 	gocloud.dev v0.15.0

--- a/velero-blockstore-openebs/main.go
+++ b/velero-blockstore-openebs/main.go
@@ -20,11 +20,13 @@ import (
 	snap "github.com/openebs/velero-plugin/pkg/snapshot"
 	zfssnap "github.com/openebs/velero-plugin/pkg/zfs/snapshot"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
 	veleroplugin "github.com/vmware-tanzu/velero/pkg/plugin/framework"
 )
 
 func main() {
 	veleroplugin.NewServer().
+		BindFlags(pflag.CommandLine).
 		RegisterVolumeSnapshotter("openebs.io/cstor-blockstore", openebsSnapPlugin).
 		RegisterVolumeSnapshotter("openebs.io/zfspv-blockstore", zfsSnapPlugin).
 		Serve()


### PR DESCRIPTION


**Why is this PR required? What issue does it fix?**:

Running the Velero deployment with Log level as Debug is not printing any debug log that plugin has.

**What this PR does**

Velero provides a logger that can be used by plugins to log structured
information to the main Velero server log or per-backup/restore logs.
It also passes a --log-level flag to each plugin binary, whose value
is the value of the same flag from the main Velero process.

This means that if you turn on debug logging for the Velero server via
--log-level=debug, plugins will also emit debug-level logs.

Signed-off-by: Pawan <pawan@mayadata.io>

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

