### PR TITLE
feat(zfspv): adding support to restore on different setup/nodes

### DIFF
--- a/changelogs/unreleased/118-pawanpraka1
+++ b/changelogs/unreleased/118-pawanpraka1
@@ -1,0 +1,1 @@
+adding support to restore on different setup/nodes

--- a/pkg/zfs/plugin/restore.go
+++ b/pkg/zfs/plugin/restore.go
@@ -90,6 +90,16 @@ func (p *Plugin) createVolume(pvname string, bkpname string, bkpZV *apis.ZFSVolu
 		// if restored volume was a clone, create a new volume instead of cloning it from a snaphsot
 		rZV.Spec.SnapName = ""
 
+		// get the target node
+		tnode, err := velero.GetTargetNode(p.K8sClient, rZV.Spec.OwnerNodeID)
+		if err != nil {
+			return nil, err
+		}
+
+		// update the target node name
+		p.Log.Debugf("zfs: GetTargetNode node %s=>%s", rZV.Spec.OwnerNodeID, tnode)
+		rZV.Spec.OwnerNodeID = tnode
+
 		// set the volume status as pending
 		rZV.Status.State = zfs.ZFSStatusPending
 


### PR DESCRIPTION
fixes : https://github.com/openebs/zfs-localpv/issues/200

Signed-off-by: Pawan <pawan@mayadata.io>


**Why is this PR required? What issue does it fix?**:

We have the node affinity set on the PV and the ZFSVolume object
which has the original node name. While doing the restore if original
nodes are not present, the Pod will not come into running state.

**What this PR does?**:

Doc: https://velero.io/docs/v1.4/restore-reference/#changing-pvc-selected-node.

Here we can create a config map which will have the node mapping like below:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  # any name can be used; Velero uses the labels (below)
  # to identify it rather than the name
  name: change-pvc-node-selector-config
  # must be in the velero namespace
  namespace: velero
  # the below labels should be used verbatim in your
  # ConfigMap.
  labels:
    # this value-less label identifies the ConfigMap as
    # config for a plugin (i.e. the built-in restore item action plugin)
    velero.io/plugin-config: ""
    # this label identifies the name and kind of plugin
    # that this ConfigMap is for.
    velero.io/change-pvc-node: RestoreItemAction
data:
  # add 1+ key-value pairs here, where the key is the old
  # node name and the value is the new node name.
  pawan-old-node1: pawan-new-node1
  pawan-old-node2: pawan-new-node2
```

While doing the restore, we will create the volume and the PV as per
the node mapping provided in the config map.




**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

