### PR TITLE
feat(zfspv): adding support to do incremental backup/restore

### DIFF
--- a/changelogs/unreleased/121-pawanpraka1
+++ b/changelogs/unreleased/121-pawanpraka1
@@ -1,1 +1,1 @@
-adding support to do incremental backup/restore
+adding support to do incremental backup/restore for ZFS-LocalPV

--- a/changelogs/unreleased/121-pawanpraka1
+++ b/changelogs/unreleased/121-pawanpraka1
@@ -1,0 +1,1 @@
+adding support to do incremental backup/restore

--- a/pkg/clouduploader/operation.go
+++ b/pkg/clouduploader/operation.go
@@ -35,13 +35,13 @@ const (
 	// Type of Key, used while listing keys
 
 	// KeyFile - if key is a file
-	KeyFile int = 1 << iota
+	ListKeyFile int = 1 << iota
 
 	// KeyDirectory - if key is a directory
-	KeyDirectory
+	ListKeyDir
 
 	// KeyBoth - if key is a file or directory
-	KeyBoth
+	ListKeyBoth
 )
 
 // Upload will perform upload operation for given file.
@@ -191,17 +191,18 @@ func (c *Conn) listKeys(prefix string, keyType int) ([]string, error) {
 		}
 
 		switch keyType {
-		case KeyBoth:
-		case KeyFile:
+		case ListKeyBoth:
+		case ListKeyFile:
 			if obj.IsDir {
 				continue
 			}
-		case KeyDirectory:
+		case ListKeyDir:
 			if !obj.IsDir {
 				continue
 			}
 		default:
 			c.Log.Warningf("Invalid keyType=%d, Ignored", keyType)
+			continue
 		}
 
 		keys = append(keys, obj.Key)
@@ -229,14 +230,14 @@ func (c *Conn) GetSnapListFromCloud(file, backup string) ([]string, error) {
 	var snapList []string
 
 	// list directory having schedule/backup name as prefix
-	dirs, err := c.listKeys(c.bkpPathPrefix(backup), KeyDirectory)
+	dirs, err := c.listKeys(c.bkpPathPrefix(backup), ListKeyDir)
 	if err != nil {
 		return snapList, errors.Wrapf(err, "failed to get list of directory")
 	}
 
 	for _, dir := range dirs {
 		// list files for dir having volume name as prefix
-		files, err := c.listKeys(dir+c.filePathPrefix(file), KeyFile)
+		files, err := c.listKeys(dir+c.filePathPrefix(file), ListKeyFile)
 		if err != nil {
 			return snapList, errors.Wrapf(err, "failed to get list of snapshot file at path=%v", dir)
 		}

--- a/pkg/zfs/plugin/zfs.go
+++ b/pkg/zfs/plugin/zfs.go
@@ -38,8 +38,8 @@ const (
 	// ZfsPvNamespace config key for OpenEBS namespace
 	ZfsPvNamespace = "namespace"
 
-	// ZfsPvBackup config key for backup type full or incremental
-	ZfsPvIncr = "incr"
+	// ZfsPvIncr config key for providing count of incremental backups
+	ZfsPvIncr = "incrBackupCount"
 
 	// zfs csi driver name
 	ZfsDriverName = "zfs.csi.openebs.io"
@@ -97,7 +97,7 @@ func (p *Plugin) Init(config map[string]string) error {
 	if count, ok := config[ZfsPvIncr]; ok {
 		incr, err := strconv.ParseUint(count, 10, 64)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "zfs: invalid incrBackupCount value=%s", count)
 		}
 		p.incremental = incr
 	}

--- a/pkg/zfs/plugin/zfs.go
+++ b/pkg/zfs/plugin/zfs.go
@@ -17,6 +17,8 @@ limitations under the License.
 package plugin
 
 import (
+	"strconv"
+
 	cloud "github.com/openebs/velero-plugin/pkg/clouduploader"
 	"github.com/openebs/velero-plugin/pkg/velero"
 	"github.com/openebs/velero-plugin/pkg/zfs/utils"
@@ -37,7 +39,7 @@ const (
 	ZfsPvNamespace = "namespace"
 
 	// ZfsPvBackup config key for backup type full or incremental
-	ZfsPvBackup = "backup"
+	ZfsPvIncr = "incr"
 
 	// zfs csi driver name
 	ZfsDriverName = "zfs.csi.openebs.io"
@@ -67,8 +69,8 @@ type Plugin struct {
 	// as env OPENEBS_NAMESPACE while deploying it.
 	namespace string
 
-	// This specify whether we have to take incremental backup or full backup
-	incremental bool
+	// This specifies how many incremental backup we have to keep
+	incremental uint64
 
 	// cl stores cloud connection information
 	cl *cloud.Conn
@@ -92,8 +94,12 @@ func (p *Plugin) Init(config map[string]string) error {
 		return errors.New("zfs: namespace not provided for ZFS-LocalPV")
 	}
 
-	if bkptype, ok := config[ZfsPvBackup]; ok && bkptype == "incremental" {
-		p.incremental = true
+	if count, ok := config[ZfsPvIncr]; ok {
+		incr, err := strconv.ParseUint(count, 10, 64)
+		if err != nil {
+			return err
+		}
+		p.incremental = incr
 	}
 
 	conf, err := rest.InClusterConfig()
@@ -123,7 +129,6 @@ func (p *Plugin) CreateVolumeFromSnapshot(snapshotID, volumeType, volumeAZ strin
 	p.Log.Debugf("zfs: CreateVolumeFromSnapshot called snap %s", snapshotID)
 
 	volumeID, err := p.doRestore(snapshotID, ZFSRestorePort)
-
 	if err != nil {
 		p.Log.Errorf("zfs: error CreateVolumeFromSnapshot returning snap %s err %v", snapshotID, err)
 		return "", err

--- a/pkg/zfs/utils/utils.go
+++ b/pkg/zfs/utils/utils.go
@@ -84,7 +84,7 @@ func GetRestorePVName() (string, error) {
 // It will check if backup name have 'bkp-20060102150405' format
 func GetScheduleName(backupName string) string {
 	// for non-scheduled backup, we are considering backup name as schedule name only
-	schdName := ""
+	schdName := backupName
 
 	// If it is scheduled backup then we need to get the schedule name
 	splitName := strings.Split(backupName, "-")
@@ -92,7 +92,7 @@ func GetScheduleName(backupName string) string {
 		_, err := time.Parse("20060102150405", splitName[len(splitName)-1])
 		if err != nil {
 			// last substring is not timestamp, so it is not generated from schedule
-			return ""
+			return schdName
 		}
 		schdName = strings.Join(splitName[0:len(splitName)-1], "-")
 	}


### PR DESCRIPTION
fixes: https://github.com/openebs/zfs-localpv/issues/199

Signed-off-by: Pawan <pawan@mayadata.io>

**Why is this PR required? What issue does it fix?**:

Adding incremental backup and restore support for ZFS-LocalPV. 

**What this PR does?**:

We can create the snapshot location as below

```yaml
apiVersion: velero.io/v1
kind: VolumeSnapshotLocation
metadata:
  name: incr
  namespace: velero
spec:
  provider: openebs.io/zfspv-blockstore
  config:
    bucket: velero
    prefix: zfs
    incrBackupCount: "3" # number of incremental backup we want to have
    namespace: openebs # this is namespace where ZFS-LocalPV creates all the CRs, passed as OPENEBS_NAMESPACE env in the ZFS-LocalPV deployment
    provider: aws
    region: minio
    s3ForcePathStyle: "true"
    s3Url: http://minio.velero.svc:9000
```

here we can specify how many incremental backups we want to have. We will create a full backup first and if we have provided non zero value for `incr` option, then the plugin will create that many incremental backup. Thing to note here is incr parameter defines how many incremental backup we want, it does not include the first full backup.


The plugin will create the incremental backup if it is scheduled backup. If it is not a scheduled backup, the ZFS-LocalPV plugin will create full backup for each request.

While doing the restore, we just need to give the backup name which we want to restore. The plugin is capable of identifying the full backup of the incremental snapshot group and will restore from the full backup and keep restoring the incremental backup till the backup name provided in the restore command.

**How can we use it?**:

There are three ways we can use the plugin for ZFS-LocalPV

- velero full backup and restore
 
```yaml
apiVersion: velero.io/v1
kind: VolumeSnapshotLocation
metadata:
  name: full
  namespace: velero
spec:
  provider: openebs.io/zfspv-blockstore
  config:
    bucket: velero
    prefix: zfs
    namespace: openebs # this is namespace where ZFS-LocalPV creates all the CRs, passed as OPENEBS_NAMESPACE env in the ZFS-LocalPV deployment
    provider: aws
    region: minio
    s3ForcePathStyle: "true"
    s3Url: http://minio.velero.svc:9000
```
- velero schedule(full) backup and restore
```yaml
apiVersion: velero.io/v1
kind: VolumeSnapshotLocation
metadata:
  name: full
  namespace: velero
spec:
  provider: openebs.io/zfspv-blockstore
  config:
    bucket: velero
    prefix: zfs
    namespace: openebs # this is namespace where ZFS-LocalPV creates all the CRs, passed as OPENEBS_NAMESPACE env in the ZFS-LocalPV deployment
    provider: aws
    region: minio
    s3ForcePathStyle: "true"
    s3Url: http://minio.velero.svc:9000
```
- velero schedule(incremental) backup and restore 
 ```yaml
apiVersion: velero.io/v1
kind: VolumeSnapshotLocation
metadata:
  name: incr
  namespace: velero
spec:
  provider: openebs.io/zfspv-blockstore
  config:
    bucket: velero
    prefix: zfs
    incrBackupCount: "3" # number of incremental backup we want to have
    namespace: openebs # this is namespace where ZFS-LocalPV creates all the CRs, passed as OPENEBS_NAMESPACE env in the ZFS-LocalPV deployment
    provider: aws
    region: minio
    s3ForcePathStyle: "true"
    s3Url: http://minio.velero.svc:9000
```

**Explanation**:

lets say we have used incrBackupCount as 3 in the volume snapshot location and created the backup. So first backup will be full backup and next 3 backup will be incremental

scdh-20201005141609 <============== incr backup, 6th backup
scdh-20201005141409 <============== full backup, 5th backup
scdh-20201005141209 <============== incr backup, 4th backup
scdh-20201005141009 <============== incr backup, 3rd backup
scdh-20201005140809 <============== incr backup, 2nd backup
scdh-20201005140600 <============== full backup, 1st backup

As we can see with incrBackupCount 3, there will be one full backup and 3 incrBackupCount backup. User does not need to know which is the full backup. We can pick any backup in the list and the plugin will find the full backup and start the restore from there to all the way upto the backup name provided in the restore command. For example if we want to restore scdh-20201005141009, the plugin will restore in the below order

1. scdh-20201005140600
2. scdh-20201005140809
3. scdh-20201005141009

It will stop at 3rd as we want to restore till scdh-20201005141009.

example 2: if we want to restore scdh-20201005141409, the plugin will restore scdh-20201005141409 only as it is full backup and we want to restore till that point only.

**Things to Consider?**:
1. Once VolumeSnapshotLocation has been created we should never modify it, we should always create a new VolumeSnapshotLocation and use that. If we want to modify it, we should cleanup old backups/schedule first and then modify it and then create a new backup/schedule.

2. Velero natively does not support the incremental backup, so while taking the incremental backup we have to set the appropriate ttl for the backups so that we have full incremental backups set available for restore. For example, if we creating a schedule to take the backup at every 30 min and VolumeSnapshotLocation says we should keep 3 incremental backups then ttl should be set to 30 min * (3 incr + 1 full) = 120 min or more. So that the full backup and all the incremental backups are available for the restore.

3. For non scheduled backup we should never use the backup name same as existing schedule name (or schedule backup name format). The plugin searches based on schedule name and in this case non scheduled backup will also get considered in "incremenatl snapshot group". So we should avoid doing that as restore will fail.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

