### PR TITLE
feat(zfspv): use schedule name to identify the scheduled backup

### DIFF
--- a/changelogs/unreleased/124-pawanpraka1
+++ b/changelogs/unreleased/124-pawanpraka1
@@ -1,0 +1,1 @@
+use schedule name to identify the scheduled backup for ZFS-LocalPV

--- a/pkg/clouduploader/operation.go
+++ b/pkg/clouduploader/operation.go
@@ -155,6 +155,24 @@ func (c *Conn) GenerateRemoteFilename(file, backup string) string {
 	return c.backupPathPrefix + "/" + backupDir + "/" + backup + "/" + c.prefix + "-" + file + "-" + backup
 }
 
+// GenerateRemoteFileWithSchd will create a file-name specific for given backup and schedule name
+func (c *Conn) GenerateRemoteFileWithSchd(file, schdname, backup string) string {
+	filePath := backupDir + "/" + backup + "/" + c.prefix
+	if len(schdname) > 0 {
+		filePath += "-" + schdname
+	}
+
+	if c.backupPathPrefix == "" {
+		return filePath + "-" + file + "-" + backup
+	}
+
+	return c.backupPathPrefix + "/" + filePath + "-" + file + "-" + backup
+}
+
+func (c *Conn) GetFileNameWithSchd(file, schdname string) string {
+	return schdname + "-" + file
+}
+
 // ConnStateReset resets the channel and exit server flag
 func (c *Conn) ConnStateReset() {
 	ch := make(chan bool, 1)

--- a/pkg/zfs/utils/utils.go
+++ b/pkg/zfs/utils/utils.go
@@ -19,7 +19,6 @@ package utils
 import (
 	"net"
 	"strings"
-	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
@@ -49,20 +48,31 @@ func GetServerAddress() (string, error) {
 	return "", errors.New("error: fetching the interface")
 }
 
-func GenerateSnapshotID(volumeID, backupName string) string {
+func GenerateResourceName(volumeID, backupName string) string {
 	return volumeID + IdentifierKey + backupName
 }
 
+func GenerateSnapshotID(volumeID, schdname, backupName string) string {
+	return volumeID + IdentifierKey + schdname + IdentifierKey + backupName
+}
+
 // GetInfoFromSnapshotID return backup name and volume id from the given snapshotID
-func GetInfoFromSnapshotID(snapshotID string) (volumeID, backupName string, err error) {
+func GetInfoFromSnapshotID(snapshotID string) (volumeID, schdname, backupName string, err error) {
 	s := strings.Split(snapshotID, IdentifierKey)
-	if len(s) != 2 {
+
+	if len(s) == 2 {
+		// backward compatibility, old backups
+		volumeID = s[0]
+		backupName = s[1]
+		schdname = ""
+	} else if len(s) == 3 {
+		volumeID = s[0]
+		schdname = s[1]
+		backupName = s[2]
+	} else {
 		err = errors.New("invalid snapshot id")
 		return
 	}
-
-	volumeID = s[0]
-	backupName = s[1]
 
 	if volumeID == "" || backupName == "" {
 		err = errors.Errorf("invalid volumeID=%s backupName=%s", volumeID, backupName)
@@ -78,23 +88,4 @@ func GetRestorePVName() (string, error) {
 	}
 
 	return RestorePrefix + nuuid.String(), nil
-}
-
-// GetScheduleName return the schedule name for the given backup
-// It will check if backup name have 'bkp-20060102150405' format
-func GetScheduleName(backupName string) string {
-	// for non-scheduled backup, we are considering backup name as schedule name only
-	schdName := backupName
-
-	// If it is scheduled backup then we need to get the schedule name
-	splitName := strings.Split(backupName, "-")
-	if len(splitName) >= 2 {
-		_, err := time.Parse("20060102150405", splitName[len(splitName)-1])
-		if err != nil {
-			// last substring is not timestamp, so it is not generated from schedule
-			return schdName
-		}
-		schdName = strings.Join(splitName[0:len(splitName)-1], "-")
-	}
-	return schdName
 }

--- a/pkg/zfs/utils/utils.go
+++ b/pkg/zfs/utils/utils.go
@@ -56,7 +56,7 @@ func GenerateSnapshotID(volumeID, schdname, backupName string) string {
 	return volumeID + IdentifierKey + schdname + IdentifierKey + backupName
 }
 
-// GetInfoFromSnapshotID return backup name and volume id from the given snapshotID
+// GetInfoFromSnapshotID return backup, schdname and volume id from the given snapshotID
 func GetInfoFromSnapshotID(snapshotID string) (volumeID, schdname, backupName string, err error) {
 	s := strings.Split(snapshotID, IdentifierKey)
 


### PR DESCRIPTION
User can create a backup using same name (or format) as scheduled backup, this
will cause restore to break as it simply does the lookup based on scheduled name.
There is no difference in the way we take the full backup and scheduled incremental
backup.

Here, we are adding schedule name in the backup file name so that we can list based on
that while doing the restore. The user created backup using schedule name will not be
considered as it is not the scheduled backup so it will not be considered while doing restore.

Signed-off-by: Pawan <pawan@mayadata.io>
