### PR TITLE
feat(zfspv): use schedule name to identify the scheduled backup (#124)

### DIFF
--- a/changelogs/unreleased/124-pawanpraka1
+++ b/changelogs/unreleased/124-pawanpraka1
@@ -1,0 +1,1 @@
+use schedule name to identify the scheduled backup for ZFS-LocalPV

--- a/pkg/clouduploader/operation.go
+++ b/pkg/clouduploader/operation.go
@@ -155,6 +155,24 @@ func (c *Conn) GenerateRemoteFilename(file, backup string) string {
 	return c.backupPathPrefix + "/" + backupDir + "/" + backup + "/" + c.prefix + "-" + file + "-" + backup
 }
 
+// GenerateRemoteFileWithSchd will create a file-name specific for given backup and schedule name
+func (c *Conn) GenerateRemoteFileWithSchd(file, schdname, backup string) string {
+	filePath := backupDir + "/" + backup + "/" + c.prefix
+	if len(schdname) > 0 {
+		filePath += "-" + schdname
+	}
+
+	if c.backupPathPrefix == "" {
+		return filePath + "-" + file + "-" + backup
+	}
+
+	return c.backupPathPrefix + "/" + filePath + "-" + file + "-" + backup
+}
+
+func (c *Conn) GetFileNameWithSchd(file, schdname string) string {
+	return schdname + "-" + file
+}
+
 // ConnStateReset resets the channel and exit server flag
 func (c *Conn) ConnStateReset() {
 	ch := make(chan bool, 1)


### PR DESCRIPTION
cherry-Pick : https://github.com/openebs/velero-plugin/pull/124

User can create a backup using same name (or format) as scheduled backup, this
will cause restore to break as it simply does the lookup based on scheduled name.
There is no difference in the way we take the full backup and scheduled incremental
backup.

Here, we are adding schedule name in the backup file name so that we can list based on
that while doing the restore. The user created backup using schedule name will not be
considered as it is not the scheduled backup so it will not be considered while doing restore.

Signed-off-by: Pawan <pawan@mayadata.io>

