### PR TITLE
fix(zfspv): fixing the backup deletion for ZFS-LocalPV

### DIFF
--- a/changelogs/unreleased/128-pawanpraka1
+++ b/changelogs/unreleased/128-pawanpraka1
@@ -1,0 +1,1 @@
+ fixing the backup deletion for ZFS-LocalPV

--- a/pkg/zfs/plugin/backup.go
+++ b/pkg/zfs/plugin/backup.go
@@ -61,7 +61,13 @@ func (p *Plugin) uploadZFSVolume(vol *apis.ZFSVolume, filename string) error {
 
 // deleteBackup deletes the backup resource
 func (p *Plugin) deleteBackup(snapshotID string) error {
-	err := bkpbuilder.NewKubeclient().WithNamespace(p.namespace).Delete(snapshotID)
+	pvname, _, snapname, err := utils.GetInfoFromSnapshotID(snapshotID)
+	if err != nil {
+		return err
+	}
+
+	bkpname := utils.GenerateResourceName(pvname, snapname)
+	err = bkpbuilder.NewKubeclient().WithNamespace(p.namespace).Delete(bkpname)
 	if err != nil {
 		p.Log.Errorf("zfs: Failed to delete the backup %s", snapshotID)
 	}

--- a/pkg/zfs/utils/utils.go
+++ b/pkg/zfs/utils/utils.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"net"
 	"strings"
+	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
@@ -64,7 +65,8 @@ func GetInfoFromSnapshotID(snapshotID string) (volumeID, schdname, backupName st
 		// backward compatibility, old backups
 		volumeID = s[0]
 		backupName = s[1]
-		schdname = ""
+		// for old backups fetch the schdeule from the bkpname
+		schdname = GetScheduleName(backupName)
 	} else if len(s) == 3 {
 		volumeID = s[0]
 		schdname = s[1]
@@ -88,4 +90,23 @@ func GetRestorePVName() (string, error) {
 	}
 
 	return RestorePrefix + nuuid.String(), nil
+}
+
+// GetScheduleName return the schedule name for the given backup
+// It will check if backup name have 'bkp-20060102150405' format
+func GetScheduleName(backupName string) string {
+	// for non-scheduled backup, we are considering backup name as schedule name only
+	schdName := ""
+
+	// If it is scheduled backup then we need to get the schedule name
+	splitName := strings.Split(backupName, "-")
+	if len(splitName) >= 2 {
+		_, err := time.Parse("20060102150405", splitName[len(splitName)-1])
+		if err != nil {
+			// last substring is not timestamp, so it is not generated from schedule
+			return schdName
+		}
+		schdName = strings.Join(splitName[0:len(splitName)-1], "-")
+	}
+	return schdName
 }


### PR DESCRIPTION
We use pvname and snapname for creating the backup. Now since we are returning schedule
name also in snapshotID, so While deleting the ZFSBackup CR we should use the pvname and snapname.

We broke this in https://github.com/openebs/velero-plugin/pull/125.

Also fixed the backup compatibility for older backups where we were not fetching the schedule name.
We should fetch the schedule name from the backup name using the naming format.

Signed-off-by: Pawan <pawan@mayadata.io>
