### PR TITLE
fix(restore): mark CVRs after restore is completed

### DIFF
--- a/changelogs/unreleased/131-zlymeda
+++ b/changelogs/unreleased/131-zlymeda
@@ -1,0 +1,1 @@
+Marking CVRs after successful restore with openebs.io/restore-completed if autoSetTargetIP=true or restoreAllIncrementalSnapshots=true

--- a/example/06-volumesnapshotlocation.yaml
+++ b/example/06-volumesnapshotlocation.yaml
@@ -43,6 +43,9 @@ spec:
     # restoreAllIncrementalSnapshots -- set it to "true", to restore all the backups from base backup to the given backup
     restoreAllIncrementalSnapshots: "false"
 
+    # autoSetTargetIP -- set it to "true", to automatically set target ip on CVR after successful restore
+    autoSetTargetIP: "true"
+
 ### Sample VolumeSnapshotLocation YAML for various cloud-providers
 # # For GCP
 #---

--- a/pkg/cstor/cstor.go
+++ b/pkg/cstor/cstor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cstor
 
 import (
+	"fmt"
 	"net"
 	"strings"
 	"time"
@@ -539,7 +540,12 @@ func (p *Plugin) CreateVolumeFromSnapshot(snapshotID, volumeType, volumeAZ strin
 	if newVol.restoreStatus == v1alpha1.RSTCStorStatusDone {
 		if p.autoSetTargetIP {
 			if err := p.markCVRsAsRestoreCompleted(newVol); err != nil {
-				return newVol.volname, err
+				readmeUrl := "https://github.com/openebs/velero-plugin#setting-targetip-in-replica"
+				errMsg := fmt.Sprintf(
+					"Error setting targetip on CVR, need to set it manually. Refer: %s",
+					readmeUrl,
+				)
+				return newVol.volname, errors.Wrapf(err, errMsg)
 			}
 		}
 

--- a/pkg/cstor/cstor.go
+++ b/pkg/cstor/cstor.go
@@ -53,6 +53,7 @@ const (
 	restoreStatusInterval = 5
 	openebsVolumeLabel    = "openebs.io/cas-type"
 	openebsCSIName        = "cstor.csi.openebs.io"
+	trueStr               = "true"
 )
 
 const (
@@ -248,7 +249,7 @@ func (p *Plugin) Init(config map[string]string) error {
 	}
 
 	if p.mayaAddr == "" && p.cvcAddr == "" {
-		return errors.New("faile to get address for maya-apiserver/cvc-server service")
+		return errors.New("failed to get address for maya-apiserver/cvc-server service")
 	}
 
 	p.cstorServerAddr = p.getServerAddress()
@@ -264,7 +265,7 @@ func (p *Plugin) Init(config map[string]string) error {
 		p.snapshots = make(map[string]*Snapshot)
 	}
 
-	if local, ok := config[LocalSnapshot]; ok && local == "true" {
+	if local, ok := config[LocalSnapshot]; ok && isTrue(local) {
 		p.local = true
 		return nil
 	}
@@ -273,13 +274,13 @@ func (p *Plugin) Init(config map[string]string) error {
 		return errors.Wrapf(err, "failed to initialize velero clientSet")
 	}
 
-	if restoreAllSnapshots, ok := config[RestoreAllIncrementalSnapshots]; ok && restoreAllSnapshots == "true" {
+	if restoreAllSnapshots, ok := config[RestoreAllIncrementalSnapshots]; ok && isTrue(restoreAllSnapshots) {
 		p.restoreAllSnapshots = true
 		p.autoSetTargetIP = true
 	}
 
 	if autoSetTargetIP, ok := config[AutoSetTargetIP]; ok {
-		p.autoSetTargetIP = autoSetTargetIP == "true"
+		p.autoSetTargetIP = isTrue(autoSetTargetIP)
 	}
 
 	p.cl = &cloud.Conn{Log: p.Log}
@@ -631,4 +632,9 @@ func getInfoFromSnapshotID(snapshotID string) (volumeID, backupName string, err 
 
 func generateSnapshotID(volumeID, backupName string) string {
 	return volumeID + SnapshotIDIdentifier + backupName
+}
+
+func isTrue(str string) bool {
+	str = strings.ToLower(str)
+	return str == trueStr || str == "yes" || str == "1"
 }

--- a/pkg/cstor/cvr_operation.go
+++ b/pkg/cstor/cvr_operation.go
@@ -208,10 +208,11 @@ func (p *Plugin) markRestoreAsCompletedForCSIBasedCVRs(vol *Volume) error {
 	}
 
 	var errs []string
-	for _, cvr := range cvrList.Items {
+	for i := range cvrList.Items {
+		cvr := cvrList.Items[i]
 		p.Log.Infof("Updating CVRs %s", cvr.Name)
 
-		cvr.Annotations[restoreCompletedAnnotation] = "true"
+		cvr.Annotations[restoreCompletedAnnotation] = trueStr
 		_, err := replicas.Update(&cvr)
 
 		if err != nil {
@@ -241,10 +242,11 @@ func (p *Plugin) markRestoreAsCompletedForNonCSIBasedCVRs(vol *Volume) error {
 	}
 
 	var errs []string
-	for _, cvr := range cvrList.Items {
+	for i := range cvrList.Items {
+		cvr := cvrList.Items[i]
 		p.Log.Infof("Updating CVRs %s", cvr.Name)
 
-		cvr.Annotations[restoreCompletedAnnotation] = "true"
+		cvr.Annotations[restoreCompletedAnnotation] = trueStr
 		_, err := replicas.Update(&cvr)
 
 		if err != nil {

--- a/pkg/cstor/cvr_operation.go
+++ b/pkg/cstor/cvr_operation.go
@@ -178,7 +178,7 @@ func (p *Plugin) markCVRsAsRestoreCompleted(vol *Volume) error {
 		return err
 	}
 
-	p.Log.Infof("Waiting for target ip to be set ono all CVRs")
+	p.Log.Infof("Waiting for target ip to be set on all CVRs")
 	if err := p.waitForTargetIpToBeSetInAllCVRs(vol); err != nil {
 		return err
 	}

--- a/pkg/cstor/cvr_operation.go
+++ b/pkg/cstor/cvr_operation.go
@@ -62,7 +62,6 @@ func (p *Plugin) waitForTargetIpToBeSetInAllCVRs(vol *Volume) error {
 
 func (p *Plugin) waitForAllCVRsToBeInValidStatus(vol *Volume, statuses []string) error {
 	replicaCount := p.getCVRCount(vol.volname, vol.isCSIVolume)
-
 	if replicaCount == -1 {
 		return errors.Errorf("Failed to fetch replicaCount for volume{%s}", vol.volname)
 	}
@@ -173,7 +172,7 @@ func (p *Plugin) markCVRsAsRestoreCompleted(vol *Volume) error {
 		return err
 	}
 
-	p.Log.Infof("Waiting for all CVRs to be ready")
+	p.Log.Infof("Marking restore as completed on CVRs")
 	if err := p.markRestoreAsCompleted(vol); err != nil {
 		p.Log.Errorf("Failed to mark restore as completed : %s", err)
 		return err

--- a/pkg/cstor/cvr_operation.go
+++ b/pkg/cstor/cvr_operation.go
@@ -17,13 +17,30 @@ limitations under the License.
 package cstor
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	cstorv1 "github.com/openebs/api/pkg/apis/cstor/v1"
-	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const (
+	cVRPVLabel                 = "openebs.io/persistent-volume"
+	restoreCompletedAnnotation = "openebs.io/restore-completed"
+)
+
+var validCvrStatusesWithoutError = []string{
+	string(cstorv1.CVRStatusOnline),
+	string(cstorv1.CVRStatusDegraded),
+}
+
+var validCvrStatuses = []string{
+	string(cstorv1.CVRStatusOnline),
+	string(cstorv1.CVRStatusError),
+	string(cstorv1.CVRStatusDegraded),
+}
 
 // CVRWaitCount control time limit for waitForAllCVR
 var CVRWaitCount = 100
@@ -34,26 +51,37 @@ var CVRCheckInterval = 5 * time.Second
 // waitForAllCVRs will ensure that all CVR related to
 // the given volume is created
 func (p *Plugin) waitForAllCVRs(vol *Volume) error {
+	return p.waitForAllCVRsToBeInValidStatus(vol, validCvrStatuses)
+}
+
+// waitForTargetIpToBeSetInAllCVRs will ensure that all CVR had
+// target ip set in zfs
+func (p *Plugin) waitForTargetIpToBeSetInAllCVRs(vol *Volume) error {
+	return p.waitForAllCVRsToBeInValidStatus(vol, validCvrStatusesWithoutError)
+}
+
+func (p *Plugin) waitForAllCVRsToBeInValidStatus(vol *Volume, statuses []string) error {
 	replicaCount := p.getCVRCount(vol.volname, vol.isCSIVolume)
+
 	if replicaCount == -1 {
 		return errors.Errorf("Failed to fetch replicaCount for volume{%s}", vol.volname)
 	}
 
 	if vol.isCSIVolume {
-		return p.waitForCSIBasedCVRs(vol, replicaCount)
+		return p.waitForCSIBasedCVRs(vol, replicaCount, statuses)
 	}
-	return p.waitFoNonCSIBasedCVRs(vol, replicaCount)
+	return p.waitFoNonCSIBasedCVRs(vol, replicaCount, statuses)
 }
 
 // waitFoNonCSIBasedCVRs will ensure that all CVRs related to
 // given non CSI based volume is created
-func (p *Plugin) waitFoNonCSIBasedCVRs(vol *Volume, replicaCount int) error {
+func (p *Plugin) waitFoNonCSIBasedCVRs(vol *Volume, replicaCount int, statuses []string) error {
 	for cnt := 0; cnt < CVRWaitCount; cnt++ {
 		cvrList, err := p.OpenEBSClient.
 			OpenebsV1alpha1().
 			CStorVolumeReplicas(p.namespace).
 			List(metav1.ListOptions{
-				LabelSelector: "openebs.io/persistent-volume=" + vol.volname,
+				LabelSelector: cVRPVLabel + "=" + vol.volname,
 			})
 		if err != nil {
 			return errors.Errorf("Failed to fetch CVR for volume=%s %s", vol.volname, err)
@@ -64,9 +92,7 @@ func (p *Plugin) waitFoNonCSIBasedCVRs(vol *Volume, replicaCount int) error {
 		}
 		cvrCount := 0
 		for _, cvr := range cvrList.Items {
-			if cvr.Status.Phase == v1alpha1.CVRStatusOnline ||
-				cvr.Status.Phase == v1alpha1.CVRStatusError ||
-				cvr.Status.Phase == v1alpha1.CVRStatusDegraded {
+			if contains(statuses, string(cvr.Status.Phase)) {
 				cvrCount++
 			}
 		}
@@ -80,13 +106,13 @@ func (p *Plugin) waitFoNonCSIBasedCVRs(vol *Volume, replicaCount int) error {
 
 // waitForCSIBasedCVRs will ensure that all CVRs related to
 // the given CSI volume is created.
-func (p *Plugin) waitForCSIBasedCVRs(vol *Volume, replicaCount int) error {
+func (p *Plugin) waitForCSIBasedCVRs(vol *Volume, replicaCount int, statuses []string) error {
 	for cnt := 0; cnt < CVRWaitCount; cnt++ {
 		cvrList, err := p.OpenEBSAPIsClient.
 			CstorV1().
 			CStorVolumeReplicas(p.namespace).
 			List(metav1.ListOptions{
-				LabelSelector: "openebs.io/persistent-volume=" + vol.volname,
+				LabelSelector: cVRPVLabel + "=" + vol.volname,
 			})
 		if err != nil {
 			return errors.Errorf("Failed to fetch CVR for volume=%s %s", vol.volname, err)
@@ -99,9 +125,7 @@ func (p *Plugin) waitForCSIBasedCVRs(vol *Volume, replicaCount int) error {
 
 		cvrCount := 0
 		for _, cvr := range cvrList.Items {
-			if cvr.Status.Phase == cstorv1.CVRStatusOnline ||
-				cvr.Status.Phase == cstorv1.CVRStatusError ||
-				cvr.Status.Phase == cstorv1.CVRStatusDegraded {
+			if contains(statuses, string(cvr.Status.Phase)) {
 				cvrCount++
 			}
 		}
@@ -139,4 +163,100 @@ func (p *Plugin) getCVRCount(volname string, isCSIVolume bool) int {
 		return -1
 	}
 	return obj.Spec.ReplicationFactor
+}
+
+// markCVRsAsRestoreCompleted wait for all CVRs to be ready, then marks CVRs are restore completed
+// and wait for CVRs to be in non-error state
+func (p *Plugin) markCVRsAsRestoreCompleted(vol *Volume) error {
+	p.Log.Infof("Waiting for all CVRs to be ready")
+	if err := p.waitForAllCVRs(vol); err != nil {
+		return err
+	}
+
+	p.Log.Infof("Waiting for all CVRs to be ready")
+	if err := p.markRestoreAsCompleted(vol); err != nil {
+		p.Log.Errorf("Failed to mark restore as completed : %s", err)
+		return err
+	}
+
+	p.Log.Infof("Waiting for target ip to be set ono all CVRs")
+	if err := p.waitForTargetIpToBeSetInAllCVRs(vol); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// markRestoreAsCompleted will mark CVRs that the restore was completed
+func (p *Plugin) markRestoreAsCompleted(vol *Volume) error {
+	if vol.isCSIVolume {
+		return p.markRestoreAsCompletedForCSIBasedCVRs(vol)
+	}
+	return p.markRestoreAsCompletedForNonCSIBasedCVRs(vol)
+}
+
+func (p *Plugin) markRestoreAsCompletedForCSIBasedCVRs(vol *Volume) error {
+	replicas := p.OpenEBSAPIsClient.CstorV1().
+		CStorVolumeReplicas(p.namespace)
+
+	cvrList, err := replicas.
+		List(metav1.ListOptions{
+			LabelSelector: cVRPVLabel + "=" + vol.volname,
+		})
+
+	if err != nil {
+		return errors.Errorf("Failed to fetch CVR for volume=%s %s", vol.volname, err)
+	}
+
+	var errs []string
+	for _, cvr := range cvrList.Items {
+		p.Log.Infof("Updating CVRs %s", cvr.Name)
+
+		cvr.Annotations[restoreCompletedAnnotation] = "true"
+		_, err := replicas.Update(&cvr)
+
+		if err != nil {
+			p.Log.Warnf("could not update CVR %s", cvr.Name)
+			errs = append(errs, err.Error())
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf(strings.Join(errs, "; "))
+	}
+
+	return nil
+}
+
+func (p *Plugin) markRestoreAsCompletedForNonCSIBasedCVRs(vol *Volume) error {
+	replicas := p.OpenEBSClient.OpenebsV1alpha1().
+		CStorVolumeReplicas(p.namespace)
+
+	cvrList, err := replicas.
+		List(metav1.ListOptions{
+			LabelSelector: cVRPVLabel + "=" + vol.volname,
+		})
+
+	if err != nil {
+		return errors.Errorf("Failed to fetch CVR for volume=%s %s", vol.volname, err)
+	}
+
+	var errs []string
+	for _, cvr := range cvrList.Items {
+		p.Log.Infof("Updating CVRs %s", cvr.Name)
+
+		cvr.Annotations[restoreCompletedAnnotation] = "true"
+		_, err := replicas.Update(&cvr)
+
+		if err != nil {
+			p.Log.Warnf("could not update CVR %s", cvr.Name)
+			errs = append(errs, err.Error())
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf(strings.Join(errs, "; "))
+	}
+
+	return nil
 }

--- a/pkg/cstor/pvc_operation.go
+++ b/pkg/cstor/pvc_operation.go
@@ -137,7 +137,7 @@ func (p *Plugin) createPVC(volumeID, snapName string) (*Volume, error) {
 		if err != nil || pvc.Status.Phase == v1.ClaimLost {
 			if err = p.K8sClient.
 				CoreV1().
-				PersistentVolumeClaims(pvc.Namespace).
+				PersistentVolumeClaims(rpvc.Namespace).
 				Delete(rpvc.Name, nil); err != nil {
 				p.Log.Warnf("Failed to delete pvc {%s/%s} : %s", rpvc.Namespace, rpvc.Name, err.Error())
 			}

--- a/pkg/snapshot/snap.go
+++ b/pkg/snapshot/snap.go
@@ -39,7 +39,7 @@ func (p *BlockStore) Init(config map[string]string) error {
 	return p.plugin.Init(config)
 }
 
-// CreateVolumeFromSnapshot Create a volume form given snapshot
+// CreateVolumeFromSnapshot Create a volume from given snapshot
 func (p *BlockStore) CreateVolumeFromSnapshot(snapshotID, volumeType, volumeAZ string, iops *int64) (string, error) {
 	return p.plugin.CreateVolumeFromSnapshot(snapshotID, volumeType, volumeAZ, iops)
 }

--- a/script/minio.yaml
+++ b/script/minio.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: velero
@@ -6,6 +6,9 @@ metadata:
   labels:
     component: minio
 spec:
+  selector:
+    matchLabels:
+      component: minio
   strategy:
     type: Recreate
   template:

--- a/script/volumesnapshotlocation.yaml
+++ b/script/volumesnapshotlocation.yaml
@@ -27,3 +27,4 @@ spec:
     s3Url: MINIO_ENDPOINT
     s3ForcePathStyle: "true"
     restoreAllIncrementalSnapshots: "true"
+    autoSetTargetIP: "true"

--- a/tests/app/application_setup.go
+++ b/tests/app/application_setup.go
@@ -71,8 +71,14 @@ func DestroyApplication(appYaml, ns string) error {
 	if err := yaml.Unmarshal([]byte(appYaml), &p); err != nil {
 		return err
 	}
-	return k8s.Client.
+	err := k8s.Client.
 		CoreV1().
 		Pods(ns).
 		Delete(p.Name, &metav1.DeleteOptions{})
+
+	if !k8serrors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
 }

--- a/tests/openebs/storage_install.go
+++ b/tests/openebs/storage_install.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
-	clientsetv1 "github.com/openebs/api/pkg/client/clientset/versioned"
 	v1alpha1 "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	clientset "github.com/openebs/maya/pkg/client/generated/clientset/versioned"
 	config "github.com/openebs/velero-plugin/tests/config"
@@ -32,10 +31,6 @@ import (
 // ClientSet interface for OpenEBS API
 type ClientSet struct {
 	clientset.Interface
-}
-
-type ClientSetV1 struct {
-	clientsetv1.Interface
 }
 
 var (

--- a/tests/openebs/storage_install.go
+++ b/tests/openebs/storage_install.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
+	clientsetv1 "github.com/openebs/api/pkg/client/clientset/versioned"
 	v1alpha1 "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	clientset "github.com/openebs/maya/pkg/client/generated/clientset/versioned"
 	config "github.com/openebs/velero-plugin/tests/config"
@@ -31,6 +32,10 @@ import (
 // ClientSet interface for OpenEBS API
 type ClientSet struct {
 	clientset.Interface
+}
+
+type ClientSetV1 struct {
+	clientsetv1.Interface
 }
 
 var (
@@ -133,7 +138,13 @@ func (c *ClientSet) DeleteVolume(pvcYAML, pvcNs string) error {
 		return err
 	}
 
-	return k8s.Client.WaitForDeploymentCleanup(
+	err = k8s.Client.WaitForDeploymentCleanup(
 		PVDeploymentLabel+"="+pv,
 		OpenEBSNs)
+
+	if err != nil {
+		return err
+	}
+
+	return k8s.Client.WaitForPVCCleanup(pvc.Name, pvc.Namespace)
 }

--- a/tests/sanity/backup_test.go
+++ b/tests/sanity/backup_test.go
@@ -160,7 +160,10 @@ var _ = Describe("Backup/Restore Test", func() {
 
 			By("Checking if restored CVR are in healthy state")
 			ok := openebs.Client.CheckCVRStatus(app.PVCName, AppNs, v1alpha1.CVRStatusOnline)
-			Expect(ok).To(BeTrue(), "CVR for PVC=%s are not in errored state", app.PVCName)
+			if !ok {
+				dumpLogs()
+			}
+			Expect(ok).To(BeTrue(), "CVR for PVC=%s are not in healthy state", app.PVCName)
 		})
 
 		It("Restore from scheduled backup", func() {
@@ -184,7 +187,10 @@ var _ = Describe("Backup/Restore Test", func() {
 
 			By("Checking if restored CVR are in healthy state")
 			ok := openebs.Client.CheckCVRStatus(app.PVCName, AppNs, v1alpha1.CVRStatusOnline)
-			Expect(ok).To(BeTrue(), "CVR for PVC=%s are not in errored state", app.PVCName)
+			if !ok {
+				dumpLogs()
+			}
+			Expect(ok).To(BeTrue(), "CVR for PVC=%s are not in healthy state", app.PVCName)
 
 			By("Checking if restore has created snapshot or not")
 			snapshotList, serr := velero.Client.GetRestoredSnapshotFromSchedule(scheduleName)
@@ -228,7 +234,10 @@ var _ = Describe("Backup/Restore Test", func() {
 
 			By("Checking if restored CVR are in healthy state")
 			ok := openebs.Client.CheckCVRStatus(app.PVCName, TargetedNs, v1alpha1.CVRStatusOnline)
-			Expect(ok).To(BeTrue(), "CVR for PVC=%s is not in errored state", app.PVCName)
+			if !ok {
+				dumpLogs()
+			}
+			Expect(ok).To(BeTrue(), "CVR for PVC=%s is not in healthy state", app.PVCName)
 		})
 
 		It("Restore from scheduled backup to different Namespace", func() {
@@ -249,7 +258,10 @@ var _ = Describe("Backup/Restore Test", func() {
 
 			By("Checking if restored CVR are in healthy state")
 			ok := openebs.Client.CheckCVRStatus(app.PVCName, TargetedNs, v1alpha1.CVRStatusOnline)
-			Expect(ok).To(BeTrue(), "CVR for PVC=%s is not in errored state", app.PVCName)
+			if !ok {
+				dumpLogs()
+			}
+			Expect(ok).To(BeTrue(), "CVR for PVC=%s is not in healthy state", app.PVCName)
 
 			By("Checking if restore has created snapshot or not")
 			snapshotList, err := velero.Client.GetRestoredSnapshotFromSchedule(scheduleName)

--- a/tests/sanity/backup_test.go
+++ b/tests/sanity/backup_test.go
@@ -158,8 +158,8 @@ var _ = Describe("Backup/Restore Test", func() {
 			Expect(perr).NotTo(HaveOccurred(), "Failed to verify PVC=%s bound status for namespace=%s", app.PVCName, AppNs)
 			Expect(phase).To(Equal(corev1.ClaimBound), "PVC=%s not bound", app.PVCName)
 
-			By("Checking if restored CVR are in error state")
-			ok := openebs.Client.CheckCVRStatus(app.PVCName, AppNs, v1alpha1.CVRStatusError)
+			By("Checking if restored CVR are in healthy state")
+			ok := openebs.Client.CheckCVRStatus(app.PVCName, AppNs, v1alpha1.CVRStatusOnline)
 			Expect(ok).To(BeTrue(), "CVR for PVC=%s are not in errored state", app.PVCName)
 		})
 
@@ -182,8 +182,8 @@ var _ = Describe("Backup/Restore Test", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to verify PVC=%s bound status for namespace=%s", app.PVCName, AppNs)
 			Expect(phase).To(Equal(corev1.ClaimBound), "PVC=%s not bound", app.PVCName)
 
-			By("Checking if restored CVR are in error state")
-			ok := openebs.Client.CheckCVRStatus(app.PVCName, AppNs, v1alpha1.CVRStatusError)
+			By("Checking if restored CVR are in healthy state")
+			ok := openebs.Client.CheckCVRStatus(app.PVCName, AppNs, v1alpha1.CVRStatusOnline)
 			Expect(ok).To(BeTrue(), "CVR for PVC=%s are not in errored state", app.PVCName)
 
 			By("Checking if restore has created snapshot or not")
@@ -226,8 +226,8 @@ var _ = Describe("Backup/Restore Test", func() {
 			Expect(perr).NotTo(HaveOccurred(), "Failed to verify PVC=%s bound status for namespace=%s", app.PVCName, TargetedNs)
 			Expect(phase).To(Equal(corev1.ClaimBound), "PVC=%s not bound", app.PVCName)
 
-			By("Checking if restored CVR are in error state")
-			ok := openebs.Client.CheckCVRStatus(app.PVCName, TargetedNs, v1alpha1.CVRStatusError)
+			By("Checking if restored CVR are in healthy state")
+			ok := openebs.Client.CheckCVRStatus(app.PVCName, TargetedNs, v1alpha1.CVRStatusOnline)
 			Expect(ok).To(BeTrue(), "CVR for PVC=%s is not in errored state", app.PVCName)
 		})
 
@@ -247,8 +247,8 @@ var _ = Describe("Backup/Restore Test", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to verify PVC=%s bound status for namespace=%s", app.PVCName, TargetedNs)
 			Expect(phase).To(Equal(corev1.ClaimBound), "PVC=%s not bound", app.PVCName)
 
-			By("Checking if restored CVR are in error state")
-			ok := openebs.Client.CheckCVRStatus(app.PVCName, TargetedNs, v1alpha1.CVRStatusError)
+			By("Checking if restored CVR are in healthy state")
+			ok := openebs.Client.CheckCVRStatus(app.PVCName, TargetedNs, v1alpha1.CVRStatusOnline)
 			Expect(ok).To(BeTrue(), "CVR for PVC=%s is not in errored state", app.PVCName)
 
 			By("Checking if restore has created snapshot or not")

--- a/tests/velero/backup.go
+++ b/tests/velero/backup.go
@@ -52,6 +52,7 @@ var (
 	SnapshotLocation string
 )
 
+// #nosec
 var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 func init() {
@@ -75,7 +76,7 @@ func generateRandomString(length int) string {
 }
 
 func (c *ClientSet) generateBackupName() (string, error) {
-	for i := 0; i < 10; {
+	for i := 0; i < 10; i++ {
 		b := generateRandomString(8)
 		if b == "" {
 			continue

--- a/tests/velero/restore.go
+++ b/tests/velero/restore.go
@@ -42,7 +42,7 @@ func (rc byCreationTimeStamp) Less(i, j int) bool {
 }
 
 func (c *ClientSet) generateRestoreName(backup string) (string, error) {
-	for i := 0; i < 10; {
+	for i := 0; i < 10; i++ {
 		r := generateRandomString(8) + "-" + backup
 		if r == "" {
 			continue

--- a/tests/velero/schedule.go
+++ b/tests/velero/schedule.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (c *ClientSet) generateScheduleName() (string, error) {
-	for i := 0; i < 10; {
+	for i := 0; i < 10; i++ {
 		b := generateRandomString(8)
 		if b == "" {
 			continue


### PR DESCRIPTION
Marking CVRs after successful restore with openebs.io/restore-completed if autoSetTargetIP=true or restoreAllIncrementalSnapshots=true

## Pull Request template

**Why is this PR required? What issue does it fix?**:
Currently users have to set targetip on CVRs after restore. This PR automates setting targetip.

**What this PR does?**:
If corresponding VolumeSnapshotLocation has autoSetTargetIP=true or restoreAllIncrementalSnapshots=true then CVRs are marked with annotation openebs.io/restore-completed which is then handled in https://github.com/openebs/maya/pull/1761 or https://github.com/openebs/cstor-operators/pull/198

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered and commands you used for testing with logs:**
I ran `make test`

**Any additional information for your reviewer?**:
_Mention if this PR is part of any design or a continuation of previous PRs_

related maya PR: https://github.com/openebs/maya/pull/1761
related cstor-operators PR: https://github.com/openebs/cstor-operators/pull/198


**Checklist:**
- [x] Fixes #127
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
