### PR TITLE
refact(builds): run only amd64 and arm64 multi arch builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ jobs:
   include:
     - os: linux
       arch: amd64
-    - os: linux
-      arch: arm64
 
 services:
   - docker

--- a/Makefile.buildx.mk
+++ b/Makefile.buildx.mk
@@ -25,7 +25,7 @@ endif
 
 # default list of platforms for which multiarch image is built
 ifeq (${PLATFORMS}, )
-	export PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le"
+	export PLATFORMS="linux/amd64,linux/arm64"
 endif
 
 # if IMG_RESULT is unspecified, by default the image will be pushed to registry

--- a/changelogs/unreleased/133-prateek
+++ b/changelogs/unreleased/133-prateek
@@ -1,0 +1,1 @@
+Multi-arch container image support for velero plugin. Migrate the multi-arch builds to github-action to support amd64 and arm64 architectures.


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>


**Why is this PR required? What issue does it fix?**:
Enabling more than two arch in the multi-arch builds is resulting in increased build times as well as
intermittent failures in running the builds.

Limiting to two archs - amd64 and arm64 for now.
