### PR TITLE
fix(travis): Travis test setup to use correct velero-plugin image

### DIFF
--- a/script/install-velero.sh
+++ b/script/install-velero.sh
@@ -107,4 +107,4 @@ ${velero} install \
 
 sed "s/MINIO_ENDPOINT/http:\/\/$MINIO_SERVER_IP\:9000/" script/volumesnapshotlocation.yaml > /tmp/s.yaml
 kubectl apply -f /tmp/s.yaml
-${velero} plugin add openebs/velero-plugin:ci
+${velero} plugin add openebs/velero-plugin-amd64:ci


### PR DESCRIPTION
Changes:
- Updating travis test setup to use `openebs/velero-plugin-amd64:ci` image instead of `openebs/velero-plugin:ci`. Ref: https://github.com/openebs/velero-plugin/pull/132

Signed-off-by: mayank <mayank.patel@mayadata.io>
