### PR TITLE
fix(restore): adding support to restore in an encrypted pool for ZFS-LocalPV

### DIFF
--- a/changelogs/unreleased/147-pawanpraka1
+++ b/changelogs/unreleased/147-pawanpraka1
@@ -1,0 +1,1 @@
+adding support to restore in an encrypted pool for ZFS-LocalPV

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/onsi/gomega v1.7.1
 	github.com/openebs/api v1.11.1-0.20200629052954-e52e2bcd8339
 	github.com/openebs/maya v0.0.0-20200411140727-1c81f9e017b0
-	github.com/openebs/zfs-localpv v1.0.0
+	github.com/openebs/zfs-localpv v1.4.1-0.20210301182642-6ec49df225fa
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1 // indirect
 	github.com/sirupsen/logrus v1.5.0
@@ -38,7 +38,6 @@ require (
 )
 
 replace (
-	github.com/openebs/zfs-localpv => github.com/pawanpraka1/zfs-localpv v0.0.0-20210216132356-3da301606743
 	k8s.io/api => k8s.io/api v0.15.12
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.15.12
 	k8s.io/apimachinery => k8s.io/apimachinery v0.15.13-beta.0

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 )
 
 replace (
+	github.com/openebs/zfs-localpv => github.com/pawanpraka1/zfs-localpv v0.0.0-20210216132356-3da301606743
 	k8s.io/api => k8s.io/api v0.15.12
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.15.12
 	k8s.io/apimachinery => k8s.io/apimachinery v0.15.13-beta.0

--- a/go.sum
+++ b/go.sum
@@ -470,12 +470,14 @@ github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/selinux v0.0.0-20170621221121-4a2974bf1ee9/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/openebs/api v1.11.1-0.20200629052954-e52e2bcd8339 h1:T6IuGc8zikB4XG+s8QTyTruJ35s1fm/P41z1AGj2rkI=
 github.com/openebs/api v1.11.1-0.20200629052954-e52e2bcd8339/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
+github.com/openebs/lib-csi v0.0.0-20201218144414-a64be5d4731e h1:40mLG8RrhwHYSS3InWsWiYVcASRgGbLWrwJkP7TS0rA=
+github.com/openebs/lib-csi v0.0.0-20201218144414-a64be5d4731e/go.mod h1:RqhCQqpcbFcAeNg54v9IOqLbY0/7S00WUa24ozC7cjI=
 github.com/openebs/maya v0.0.0-20200411140727-1c81f9e017b0 h1:9o6+N3YkssQvUlmJnqNULSxsGFO/rb1we8MtYKr5ze4=
 github.com/openebs/maya v0.0.0-20200411140727-1c81f9e017b0/go.mod h1:QQY9cOHKQwZ73qbv6O//UYUBLNV2S0MRDIfG7t5KOCk=
-github.com/openebs/zfs-localpv v1.0.0 h1:aBXyYEFN+5NTGiqT6xnqLp1N34U8AUbh9vlhSA8BQnI=
-github.com/openebs/zfs-localpv v1.0.0/go.mod h1:EvN06mQH8s6oGq4ybAs1DLqy0fVS3CDh7xmvPLBQtpE=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
+github.com/pawanpraka1/zfs-localpv v0.0.0-20210216132356-3da301606743 h1:sOaikRC0siAReC7RLBNGk0MkLWJTqvFOabEbNWSbNnc=
+github.com/pawanpraka1/zfs-localpv v0.0.0-20210216132356-3da301606743/go.mod h1:/gL8B1DN2eu1uBNK4cbypr8GEAnMmlf/rC7tH+yxREM=
 github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.0.1/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/go.sum
+++ b/go.sum
@@ -474,10 +474,10 @@ github.com/openebs/lib-csi v0.0.0-20201218144414-a64be5d4731e h1:40mLG8RrhwHYSS3
 github.com/openebs/lib-csi v0.0.0-20201218144414-a64be5d4731e/go.mod h1:RqhCQqpcbFcAeNg54v9IOqLbY0/7S00WUa24ozC7cjI=
 github.com/openebs/maya v0.0.0-20200411140727-1c81f9e017b0 h1:9o6+N3YkssQvUlmJnqNULSxsGFO/rb1we8MtYKr5ze4=
 github.com/openebs/maya v0.0.0-20200411140727-1c81f9e017b0/go.mod h1:QQY9cOHKQwZ73qbv6O//UYUBLNV2S0MRDIfG7t5KOCk=
+github.com/openebs/zfs-localpv v1.4.1-0.20210301182642-6ec49df225fa h1:yrYcB+jDNlrkSD7FBzy1TxVcy3yB6X1ttjHeOwH304g=
+github.com/openebs/zfs-localpv v1.4.1-0.20210301182642-6ec49df225fa/go.mod h1:/gL8B1DN2eu1uBNK4cbypr8GEAnMmlf/rC7tH+yxREM=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
-github.com/pawanpraka1/zfs-localpv v0.0.0-20210216132356-3da301606743 h1:sOaikRC0siAReC7RLBNGk0MkLWJTqvFOabEbNWSbNnc=
-github.com/pawanpraka1/zfs-localpv v0.0.0-20210216132356-3da301606743/go.mod h1:/gL8B1DN2eu1uBNK4cbypr8GEAnMmlf/rC7tH+yxREM=
 github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.0.1/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=


### PR DESCRIPTION
fixes: https://github.com/openebs/zfs-localpv/issues/286

Signed-off-by: Pawan <pawan@mayadata.io>


**Why is this PR required? What issue does it fix?**:

Encrypted pool does not allow the volume to be pre created for the
restore purpose.

**What this PR does?**:
 Here changing the design to do the restore first
and then create the ZFSVolume object which will bind the volume
already created while doing restore.

**Does this PR require any upgrade changes?**:

Backward compatibility is maintained by ZFS-LocalPV.

**Depends On**

https://github.com/openebs/zfs-localpv/pull/292