### PR TITLE
fix(timeout): Adding new VSL parameter to set timeout for HTTP request

### DIFF
--- a/changelogs/unreleased/154-mynktl
+++ b/changelogs/unreleased/154-mynktl
@@ -1,0 +1,2 @@
+Adding a new VolumeSnapshotLocation config parameter restApiTimeout to configure timeout for HTTP REST request between plugin and cstor services
+

--- a/example/06-local-volumesnapshotlocation.yaml
+++ b/example/06-local-volumesnapshotlocation.yaml
@@ -26,3 +26,8 @@ spec:
     namespace: <OPENEBS_NAMESPACE>
 
     local: "true"
+
+    # restApiTimeout -- http timeout for rest call between velero-plugin and openebs services
+    # if not set, default timeout will be 60s.
+    # example value: 60s, 2m..
+    restApiTimeout: 1m

--- a/example/06-volumesnapshotlocation.yaml
+++ b/example/06-volumesnapshotlocation.yaml
@@ -46,6 +46,11 @@ spec:
     # autoSetTargetIP -- set it to "true", to automatically set target ip on CVR after successful restore
     autoSetTargetIP: "true"
 
+    # restApiTimeout -- http timeout for rest call between velero-plugin and openebs services
+    # if not set, default timeout will be 60s.
+    # example value: 60s, 2m..
+    restApiTimeout: 1m
+
 ### Sample VolumeSnapshotLocation YAML for various cloud-providers
 # # For GCP
 #---
@@ -60,6 +65,7 @@ spec:
 #     bucket: openebs-velero-example
 #     prefix: cstor
 #     provider: gcp
+#     restApiTimeout: 1m
 
 #
 # # For MinIO
@@ -105,6 +111,8 @@ spec:
 #     # If you want to disable certificate verification then set insecureSkipTLSVerify to "true"
 #     # By default insecureSkipTLSVerify is set to "false"
 #     insecureSkipTLSVerify: "false"
+#
+#     restApiTimeout: 1m
 
 #
 # # For AWS
@@ -143,3 +151,5 @@ spec:
 #     # If you want to disable certificate verification then set insecureSkipTLSVerify to "true"
 #     # By default insecureSkipTLSVerify is set to "false"
 #     insecureSkipTLSVerify: "false"
+#
+#     restApiTimeout: 1m

--- a/pkg/cstor/api_service.go
+++ b/pkg/cstor/api_service.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
-	"time"
 
 	v1alpha1 "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	"github.com/pkg/errors"
@@ -39,7 +38,7 @@ func (p *Plugin) httpRestCall(url, reqtype string, data []byte) ([]byte, error) 
 	req.Header.Add("Content-Type", "application/json")
 
 	c := &http.Client{
-		Timeout: 60 * time.Second,
+		Timeout: p.restTimeout,
 	}
 
 	resp, err := c.Do(req)
@@ -302,7 +301,7 @@ func (p *Plugin) sendDeleteRequest(backup, volume, namespace, schedule string, i
 	req.URL.RawQuery = q.Encode()
 
 	c := &http.Client{
-		Timeout: 60 * time.Second,
+		Timeout: p.restTimeout,
 	}
 
 	resp, err := c.Do(req)


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
Fixes https://github.com/openebs/velero-plugin/issues/148

**What this PR does?**:
This PR adds a new VolumeSnapshotLocation config parameter `restApiTimeout` to configure the timeout for HTTP REST requests between plugin and cstor services.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered and commands you used for testing with logs:**
yes. testing logs
```
time="2021-04-30T12:36:30Z" level=info msg="Initializing velero plugin for CStor" backup=velero/b1 cmd=/plugins/velero-blockstore-openebs logSource="/home/mayank/go/src/github.com/openebs/velero-plugin/pkg/snapshot/snap.go:36" pluginName=velero-blockstore-openebs
time="2021-04-30T12:36:30Z" level=info msg="Ip address of velero-plugin server: 172.17.0.15" backup=velero/b1 cmd=/plugins/velero-blockstore-openebs logSource="/home/mayank/go/src/github.com/openebs/velero-plugin/pkg/cstor/cstor.go:207" pluginName=velero-blockstore-openebs
time="2021-04-30T12:36:30Z" level=info msg="Setting restApiTimeout to 5m0s" backup=velero/b1 cmd=/plugins/velero-blockstore-openebs logSource="/home/mayank/go/src/github.com/openebs/velero-plugin/pkg/cstor/cstor.go:285" pluginName=velero-blockstore-openebs
time="2021-04-30T12:36:30Z" level=info msg="Got volume ID for persistent volume" backup=velero/b1 logSource="pkg/backup/item_backupper.go:462" name=pvc-ecb101f4-138c-4f9e-af21-ebcb7e2b6946 namespace= persistentVolume=pvc-ecb101f4-138c-4f9e-af21-ebcb7e2b6946 resource=persistentvolumes volumeSnapshotLocation=default
```

**Any additional information for your reviewer?**:
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes https://github.com/openebs/velero-plugin/issues/148
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
