### PR TITLE
Replace for true{}  with for{}

### DIFF
--- a/pkg/zfs/plugin/restore.go
+++ b/pkg/zfs/plugin/restore.go
@@ -186,7 +186,7 @@ func (p *Plugin) checkRestoreStatus(rname string) error {
 
 func (p *Plugin) checkVolCreation(volname string) error {
 
-	for true {
+	for {
 
 		getOptions := metav1.GetOptions{}
 		vol, err := volbuilder.NewKubeclient().


### PR DESCRIPTION
Signed-off-by: Sonia Singla <soniasingla.1812@gmail.com>

Replace `for true{}`  with `for{}`