### PR TITLE
(bugbash) style(zfspv): Removing redundant pieces of code

### DIFF
--- a/pkg/velero/velero.go
+++ b/pkg/velero/velero.go
@@ -40,9 +40,6 @@ func InitializeClientSet(config *rest.Config) error {
 	var err error
 
 	clientSet, err = veleroclient.NewForConfig(config)
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }

--- a/pkg/zfs/plugin/zfs.go
+++ b/pkg/zfs/plugin/zfs.go
@@ -162,7 +162,7 @@ func (p *Plugin) CreateSnapshot(volumeID, volumeAZ string, tags map[string]strin
 		return "", errors.New("zfs: error get backup name")
 	}
 
-	schdname, _ := tags[VeleroSchdKey]
+	schdname := tags[VeleroSchdKey]
 
 	snapshotID, err := p.doBackup(volumeID, bkpname, schdname, ZFSBackupPort)
 


### PR DESCRIPTION
Signed-off-by: Rahul Grover <rahulgrover99@gmail.com>

**Why is this PR required? What issue does it fix?**:
Improves code quality. Removes `S1005` (Drop unnecessary use of the blank identifier) and `opt.semgrep.err-nil-check`

**What this PR does?**:
It removes superfluous nil err check before return and unnecessary assignment to the blank identifier.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered and commands you used for testing with logs:**
NA

**Any additional information for your reviewer?**:
_Mention if this PR is part of any design or a continuation of previous PRs_
NA

