### PR TITLE
docs(velero-plugin): Update documentation to point to multiarch image…

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,7 @@ _Velero-plugin version **< 1.11.0** is not supported for cstor v1 volumes._
 
 _If you want to use plugin image from development branch(`master`), use **ci** tag._
 
-Plugin images are available at:
-
-For AMD64: [quay.io](http://quay.io/openebs/velero-plugin) and [hub.docker.com](https://hub.docker.com/r/openebs/velero-plugin/tags).
-
-For ARM64: [quay.io](https://quay.io/repository/openebs/velero-plugin-arm64?tab=tags) and [hub.docker.com](https://hub.docker.com/r/openebs/velero-plugin-arm64/tags).
+Multiarch (amd64/arm64) plugin images are available at [Docker Hub](https://hub.docker.com/r/openebs/velero-plugin/tags).
 
 ## Prerequisite for velero-plugin
 A Specific version of Velero needs to be installed as per the [compatibility matrix](#Compatibility-matrix) with OpenEBS versions.
@@ -74,8 +70,6 @@ For installation steps of OpenEBS, visit https://github.com/openebs/openebs/rele
 Run the following command to install development image of OpenEBS velero-plugin
 
 `velero plugin add openebs/velero-plugin:1.9.0`
-
-For ARM64, change image name to `openebs/velero-plugin-arm64`.
 
 This command will add an init container to Velero deployment to install the OpenEBS velero-plugin.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,16 +28,9 @@ The format of the release tag is either "Release-Name-RC1" or "Release-Name" dep
 
 Once the release is triggered, github actions release workflow process has to be monitored. Once github actions release workflow is passed images are pushed to docker hub and quay.io. Images can be verified by going through docker hub and quay.io. Also the images shouldn't have any high-level vulnerabilities.
 
-Images are published at the following location:
-for AMD64:
+Multiarch (amd64/arm64) images are published at the following location:
 ```
-https://quay.io/repository/openebs/velero-plugin?tab=tags
 https://hub.docker.com/r/openebs/velero-plugin/tags
-```
-for ARM64:
-```
-https://quay.io/repository/openebs/velero-plugin-arm64?tab=tags
-https://hub.docker.com/r/openebs/velero-plugin-arm64/tags
 ```
 
 


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
The README still points to outdated images on Docker Hub and quay. These aren't updated anymore. The primary images are now nicely multiarch and useable on both amd64 and arm64. :-)

**Checklist:**
- [ ] Fixes #<issue number>
- [X] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: