### PR TITLE
chore: fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
 # Default code owners
-*                           @openebs/localpv-zfs-approvers @openebs/org-maintainers
+*                           @openebs/localpv-zfs-approvers
 
-# CODEOWNERS file owners
 /.github/CODEOWNERS         @openebs/org-maintainers
 
 # Policy docs owners


### PR DESCRIPTION
Change:
- Remove requirement for an @openebs/org-maintainers member's review when merging non-policy documents.
- Settings changes:
   - Mandate code owner approval
   - Ensure required approval is set to 1